### PR TITLE
fix(plex): concurrent map writes on Header with match parallelism

### DIFF
--- a/plex/accept_identity_transport.go
+++ b/plex/accept_identity_transport.go
@@ -1,22 +1,33 @@
 package plex
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 // acceptIdentityTransport sets Accept-Encoding: identity on outbound requests when unset.
 // Plex returns large XML; forcing identity skips net/http's gzipReader wrapper around the
 // response body, which can interact badly with bodyEOFSignal under real Plex traffic.
+//
+// RoundTrip always clones before mutating headers so the caller's *http.Request is never
+// written to by this layer (safe with parallel callers sharing patterns and net/http).
 type acceptIdentityTransport struct {
 	base http.RoundTripper
 }
 
 func (t *acceptIdentityTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("nil request")
+	}
 	base := t.base
 	if base == nil {
 		base = http.DefaultTransport
 	}
-	r := req
-	if req.Header.Get("Accept-Encoding") == "" {
-		r = req.Clone(req.Context())
+	r := req.Clone(req.Context())
+	if r == nil {
+		return nil, fmt.Errorf("http.Request.Clone returned nil")
+	}
+	if r.Header.Get("Accept-Encoding") == "" {
 		r.Header.Set("Accept-Encoding", "identity")
 	}
 	return base.RoundTrip(r)

--- a/plex/accept_identity_transport_test.go
+++ b/plex/accept_identity_transport_test.go
@@ -39,6 +39,9 @@ func TestAcceptIdentityTransport_SetsIdentityWhenHeaderUnset(t *testing.T) {
 	if seen != "identity" {
 		t.Fatalf("Accept-Encoding: got %q, want identity", seen)
 	}
+	if got := req.Header.Get("Accept-Encoding"); got != "" {
+		t.Fatalf("caller request must not be mutated; Accept-Encoding got %q", got)
+	}
 }
 
 func TestAcceptIdentityTransport_PreservesExplicitAcceptEncoding(t *testing.T) {

--- a/plex/http_do.go
+++ b/plex/http_do.go
@@ -2,6 +2,7 @@ package plex
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -12,18 +13,35 @@ import (
 // when req.Context has no deadline. The cancel func runs when resp.Body is closed
 // (or immediately if Do returns an error).
 //
+// The outbound request is always a clone of req. net/http may mutate the request
+// during redirects; sharing the caller's *http.Request across goroutines (e.g. parallel
+// track matching) plus transport mutation caused concurrent map writes on Header.
+//
 // [http.Client.Timeout] must be zero when using custom RoundTripper wrappers: if the
 // transport is not *http.Transport, net/http falls back to setRequestCancel's legacy
 // timer goroutine, which can fatally error on Go 1.26+ ("select on synctest…").
 func (c *Client) httpDo(req *http.Request) (*http.Response, error) {
-	if _, ok := req.Context().Deadline(); ok {
-		return c.httpClient.Do(req)
+	if req == nil {
+		return nil, fmt.Errorf("nil request")
 	}
-	ctx, cancel := context.WithTimeout(req.Context(), DefaultHTTPTimeout)
-	req = req.Clone(ctx)
-	resp, err := c.httpClient.Do(req)
+	baseCtx := req.Context()
+	sendCtx := baseCtx
+	var cancel context.CancelFunc
+	if _, hasDeadline := baseCtx.Deadline(); !hasDeadline {
+		sendCtx, cancel = context.WithTimeout(baseCtx, DefaultHTTPTimeout)
+	}
+	reqSend := req.Clone(sendCtx)
+	if reqSend == nil {
+		if cancel != nil {
+			cancel()
+		}
+		return nil, fmt.Errorf("http.Request.Clone returned nil")
+	}
+	resp, err := c.httpClient.Do(reqSend)
 	if err != nil {
-		cancel()
+		if cancel != nil {
+			cancel()
+		}
 		return nil, err
 	}
 	body := resp.Body
@@ -31,7 +49,11 @@ func (c *Client) httpDo(req *http.Request) (*http.Response, error) {
 		// net/http usually sets a non-nil Body; guard so xml.NewDecoder never sees a nil Reader.
 		body = io.NopCloser(strings.NewReader(""))
 	}
-	resp.Body = &bodyCancelCloser{ReadCloser: body, cancel: cancel}
+	if cancel != nil {
+		resp.Body = &bodyCancelCloser{ReadCloser: body, cancel: cancel}
+	} else {
+		resp.Body = body
+	}
 	return resp, nil
 }
 

--- a/plex/http_do_race_test.go
+++ b/plex/http_do_race_test.go
@@ -1,0 +1,74 @@
+package plex
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestHTTPDo_ConcurrentDoesNotRaceOnCallerHeader stresses parallel Plex-style GETs through
+// httpDo + acceptIdentityTransport (same stack as production match concurrency).
+func TestHTTPDo_ConcurrentDoesNotRaceOnCallerHeader(t *testing.T) {
+	t.Parallel()
+
+	const workers = 64
+	var wg sync.WaitGroup
+	base := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Header.Get("Accept-Encoding") != "identity" {
+			t.Errorf("missing identity Accept-Encoding: %q", r.Header.Get("Accept-Encoding"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("<MediaContainer></MediaContainer>")),
+		}, nil
+	})
+
+	c := &Client{
+		httpClient: &http.Client{
+			Transport: &acceptIdentityTransport{base: base},
+			Timeout:   0,
+		},
+	}
+
+	ctx := context.Background()
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			u := "http://plex.test/search?q=" + strconv.Itoa(i)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			req.Header.Set("Accept", "application/xml")
+			req.Header.Set("X-Worker", strconv.Itoa(i))
+			if v := req.Header.Get("Accept"); v != "application/xml" {
+				t.Errorf("header before httpDo: %q", v)
+				return
+			}
+			resp, err := c.httpDo(req)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+				t.Error(err)
+			}
+			if err := resp.Body.Close(); err != nil {
+				t.Error(err)
+			}
+			if v := req.Header.Get("Accept-Encoding"); v != "" {
+				t.Errorf("caller request must not gain Accept-Encoding after RoundTrip; got %q", v)
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Cause
With `PLEX_MATCH_CONCURRENCY` > 1, many goroutines run `SearchTrack` → `httpDo` → `net/http` in parallel. The branch of `httpDo` used when the request context **already had a deadline** forwarded the caller's `*http.Request` straight into `Client.Do`. The transport may mutate that request (redirects, etc.). Another goroutine can be executing `Header.Set` on its own request while the shared `http.Transport` mutates headers, or (depending on timing) the same header map can be observed incorrectly—Go then fatals with **concurrent map writes** (seen under `searchByCombinedQuery` at `Header.Set("Accept", ...)`).

## Fix
- **Always** `req.Clone(sendCtx)` before `httpClient.Do` so `net/http` only mutates the clone.
- **`acceptIdentityTransport`**: always clone before setting `Accept-Encoding: identity`, so this layer never writes the caller's header map.

## Tests
- `go test ./... -race`
- New `TestHTTPDo_ConcurrentDoesNotRaceOnCallerHeader` (64 parallel workers)
- `TestAcceptIdentityTransport_SetsIdentityWhenHeaderUnset` now asserts the original request is not mutated.

Made with [Cursor](https://cursor.com)