### PR TITLE
fix(plex): K8s reliability and HTTP pipeline serialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Plexify Makefile
 # Build and development tools for the Plexify application
 
-.PHONY: help build run test clean deps format vet lint setup build-release build-all-platforms
+.PHONY: help build run test clean deps format fmt vet lint setup build-release build-all-platforms
 
 # Default target
 .DEFAULT_GOAL := help
@@ -21,14 +21,15 @@ help: ## Show this help message
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 	@echo "Examples:"
-	@echo "  make build          # Build the application"
+	@echo "  make build          # Format then build the application"
 	@echo "  make run            # Run the application"
 	@echo "  make test           # Run tests"
+	@echo "  make fmt            # Format code (alias for make format)"
 	@echo "  make setup          # Setup development environment"
 	@echo "  make build-release  # Build for all platforms"
 
 # Build targets
-build: ## Build the application for current platform
+build: format ## Build the application for current platform (runs format first)
 	@echo "Building $(BINARY_NAME)..."
 	go build $(LDFLAGS) -o $(BINARY_NAME) $(MAIN_FILE)
 	@echo "Build complete: ./$(BINARY_NAME)"
@@ -102,6 +103,8 @@ test-verbose: ## Run tests with verbose output
 format: ## Format the code
 	@echo "Formatting code..."
 	go fmt ./...
+
+fmt: format ## Alias for format (run: make fmt)
 
 vet: ## Vet the code
 	@echo "Vetting code..."

--- a/plex/client.go
+++ b/plex/client.go
@@ -5,9 +5,11 @@ import (
 	"crypto/tls"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/LukeHagar/plexgo"
@@ -53,6 +55,9 @@ type Client struct {
 	sectionID             int
 	serverID              string
 	httpClient            *http.Client
+	// httpPipelineMu is held from the start of each outbound RoundTrip until the response body
+	// is closed (see pipelineLockTransport). Do not copy Client by value while using the client.
+	httpPipelineMu        sync.Mutex
 	debug                 bool
 	plexgoClient          *plexgo.PlexAPI
 	matchConcurrency      int
@@ -131,25 +136,42 @@ func NewClientWithTLSConfig(cfg *config.Config, skipTLSVerify bool) *Client {
 	// Client.Timeout would use setRequestCancel's legacy path (broken vs synctest on Go 1.26+).
 	httpClient := &http.Client{Timeout: 0}
 
-	var baseTransport http.RoundTripper = http.DefaultTransport
-	if skipTLSVerify {
-		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
-			tr := dt.Clone()
+	// Always clone DefaultTransport for isolated dial/idle-pool settings. Parallel track matching
+	// plus rate limiting benefits from a higher per-host idle cap than the zero-value Transport
+	// (Colima/Docker NAT paths are more sensitive to connection churn than a typical desktop).
+	var baseTransport http.RoundTripper
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		tr := dt.Clone()
+		if skipTLSVerify {
 			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
-			baseTransport = tr
-		} else {
-			baseTransport = &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-			}
 		}
+		if tr.MaxIdleConnsPerHost < 32 {
+			tr.MaxIdleConnsPerHost = 32
+		}
+		if tr.MaxIdleConns < 64 {
+			tr.MaxIdleConns = 64
+		}
+		baseTransport = tr
+	} else if skipTLSVerify {
+		baseTransport = &http.Transport{
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			MaxIdleConns:          64,
+			MaxIdleConnsPerHost:   32,
+		}
+	} else {
+		baseTransport = http.DefaultTransport
 	}
 
 	rps := cfg.Plex.MaxRequestsPerSecond
-	var rt http.RoundTripper = baseTransport
+	var inner http.RoundTripper = baseTransport
 	if rps > 0 {
-		rt = newRateLimitedTransport(baseTransport, rps)
+		inner = newRateLimitedTransport(baseTransport, rps)
 	}
-	httpClient.Transport = &acceptIdentityTransport{base: rt}
+
+	c := new(Client)
+	httpClient.Transport = &acceptIdentityTransport{
+		base: newPipelineLockTransport(&c.httpPipelineMu, inner),
+	}
 
 	plexgoClient := plexgo.New(
 		plexgo.WithSecurity(cfg.Plex.Token),
@@ -167,20 +189,19 @@ func NewClientWithTLSConfig(cfg *config.Config, skipTLSVerify bool) *Client {
 
 	mp := cfg.Plex.MatchConfidencePercent
 	mpCopy := mp
-	return &Client{
-		baseURL:                cfg.Plex.URL,
-		token:                  cfg.Plex.Token,
-		sectionID:              cfg.Plex.LibrarySectionID,
-		serverID:               cfg.Plex.ServerID,
-		httpClient:             httpClient,
-		debug:                  false,
-		plexgoClient:           plexgoClient,
-		matchConcurrency:       mc,
-		dryRun:                 cfg.Plex.DryRun,
-		skipFullLibrarySearch:  cfg.Plex.SkipFullLibrarySearch,
-		exactMatchesOnly:       cfg.Plex.ExactMatchesOnly,
-		matchConfidencePercent: &mpCopy,
-	}
+	c.baseURL = cfg.Plex.URL
+	c.token = cfg.Plex.Token
+	c.sectionID = cfg.Plex.LibrarySectionID
+	c.serverID = cfg.Plex.ServerID
+	c.httpClient = httpClient
+	c.debug = false
+	c.plexgoClient = plexgoClient
+	c.matchConcurrency = mc
+	c.dryRun = cfg.Plex.DryRun
+	c.skipFullLibrarySearch = cfg.Plex.SkipFullLibrarySearch
+	c.exactMatchesOnly = cfg.Plex.ExactMatchesOnly
+	c.matchConfidencePercent = &mpCopy
+	return c
 }
 
 func (c *Client) minMatchScore() float64 {
@@ -258,7 +279,8 @@ func (c *Client) GetServerInfo(ctx context.Context) (*PlexServerInfo, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
-		return nil, fmt.Errorf("plex server info API returned status %d", resp.StatusCode)
+		b, _ := io.ReadAll(resp.Body)
+		return nil, newPlexHTTPError(resp.StatusCode, "server info", b)
 	}
 
 	var serverInfo PlexServerInfo
@@ -271,16 +293,41 @@ func (c *Client) GetServerInfo(ctx context.Context) (*PlexServerInfo, error) {
 
 // GetServerID retrieves the server ID (machine identifier) from the Plex API
 func (c *Client) GetServerID(ctx context.Context) (string, error) {
-	serverInfo, err := c.GetServerInfo(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get server info: %w", err)
-	}
+	const maxAttempts = 4
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(250*(1<<(attempt-1))) * time.Millisecond
+			if delay > 3*time.Second {
+				delay = 3 * time.Second
+			}
+			select {
+			case <-ctx.Done():
+				return "", fmt.Errorf("failed to get server info: %w", ctx.Err())
+			case <-time.After(delay):
+			}
+		}
 
-	if serverInfo.MachineIdentifier == "" {
-		return "", fmt.Errorf("server info response does not contain machine identifier")
-	}
+		serverInfo, err := c.GetServerInfo(ctx)
+		if err != nil {
+			lastErr = err
+			if ctx.Err() != nil {
+				return "", fmt.Errorf("failed to get server info: %w", err)
+			}
+			if isTransientPlexErr(err) && attempt+1 < maxAttempts {
+				slog.WarnContext(ctx, "transient error fetching Plex server info; retrying",
+					"err", err, "attempt", attempt+1, "max", maxAttempts)
+				continue
+			}
+			return "", fmt.Errorf("failed to get server info: %w", err)
+		}
 
-	return serverInfo.MachineIdentifier, nil
+		if serverInfo.MachineIdentifier == "" {
+			return "", fmt.Errorf("server info response does not contain machine identifier")
+		}
+		return serverInfo.MachineIdentifier, nil
+	}
+	return "", fmt.Errorf("failed to get server info: %w", lastErr)
 }
 
 // SetServerID updates the server ID in the client

--- a/plex/client.go
+++ b/plex/client.go
@@ -50,11 +50,11 @@ const (
 
 // Client wraps the Plex API client
 type Client struct {
-	baseURL               string
-	token                 string
-	sectionID             int
-	serverID              string
-	httpClient            *http.Client
+	baseURL    string
+	token      string
+	sectionID  int
+	serverID   string
+	httpClient *http.Client
 	// httpPipelineMu is held from the start of each outbound RoundTrip until the response body
 	// is closed (see pipelineLockTransport). Do not copy Client by value while using the client.
 	httpPipelineMu        sync.Mutex
@@ -154,9 +154,9 @@ func NewClientWithTLSConfig(cfg *config.Config, skipTLSVerify bool) *Client {
 		baseTransport = tr
 	} else if skipTLSVerify {
 		baseTransport = &http.Transport{
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
-			MaxIdleConns:          64,
-			MaxIdleConnsPerHost:   32,
+			TLSClientConfig:     &tls.Config{InsecureSkipVerify: true},
+			MaxIdleConns:        64,
+			MaxIdleConnsPerHost: 32,
 		}
 	} else {
 		baseTransport = http.DefaultTransport

--- a/plex/client_test.go
+++ b/plex/client_test.go
@@ -74,7 +74,11 @@ func TestNewClient_HTTPClientUsesZeroTimeoutAndAcceptIdentityTransport(t *testin
 	if outer.base == nil {
 		t.Fatal("acceptIdentityTransport.base is nil")
 	}
-	if _, ok := outer.base.(*rateLimitedTransport); ok {
+	lock, ok := outer.base.(*pipelineLockTransport)
+	if !ok {
+		t.Fatalf("expected *pipelineLockTransport under accept identity, got %T", outer.base)
+	}
+	if _, ok := lock.base.(*rateLimitedTransport); ok {
 		t.Fatal("MaxRequestsPerSecond=0 must not wrap rateLimitedTransport")
 	}
 }
@@ -97,9 +101,13 @@ func TestNewClient_RateLimitWrappedUnderAcceptIdentityTransport(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *acceptIdentityTransport, got %T", client.httpClient.Transport)
 	}
-	lim, ok := outer.base.(*rateLimitedTransport)
+	lock, ok := outer.base.(*pipelineLockTransport)
 	if !ok {
-		t.Fatalf("expected rate limiter inside accept identity, got %T", outer.base)
+		t.Fatalf("expected *pipelineLockTransport inside accept identity, got %T", outer.base)
+	}
+	lim, ok := lock.base.(*rateLimitedTransport)
+	if !ok {
+		t.Fatalf("expected rate limiter inside pipeline lock, got %T", lock.base)
 	}
 	if lim.base == nil || lim.minGap <= 0 {
 		t.Fatalf("rateLimitedTransport not wired: base=%v minGap=%v", lim.base, lim.minGap)

--- a/plex/errors.go
+++ b/plex/errors.go
@@ -4,11 +4,53 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"net/url"
+	"strings"
 	"syscall"
 )
+
+const maxPlexHTTPErrorBody = 2048
+
+// PlexHTTPError is returned when the Plex HTTP API responds with an unexpected status code.
+// Transient statuses (5xx, 408, 429) are recognized by [isTransientPlexErr] for retries and soft-degrades.
+type PlexHTTPError struct {
+	StatusCode int
+	Op         string
+	Body       string
+}
+
+func newPlexHTTPError(status int, op string, body []byte) *PlexHTTPError {
+	s := string(body)
+	if len(s) > maxPlexHTTPErrorBody {
+		s = s[:maxPlexHTTPErrorBody] + "…"
+	}
+	s = strings.ReplaceAll(s, "\x00", "")
+	return &PlexHTTPError{StatusCode: status, Op: op, Body: strings.TrimSpace(s)}
+}
+
+func (e *PlexHTTPError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Body != "" {
+		return fmt.Sprintf("plex %s: HTTP %d: %s", e.Op, e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("plex %s: HTTP %d", e.Op, e.StatusCode)
+}
+
+// transientHTTPStatus reports status codes that often succeed on retry (overloaded Plex, proxies, K8s paths).
+func transientHTTPStatus(code int) bool {
+	switch code {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true
+	default:
+		return code >= 500 && code <= 599
+	}
+}
 
 // isTransientPlexErr reports unknown or transport-level failures that are worth retrying
 // or skipping to the next search strategy, rather than aborting the whole track match.
@@ -46,6 +88,10 @@ func isTransientPlexErr(err error) bool {
 		return true
 	}
 	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var pe *PlexHTTPError
+	if errors.As(err, &pe) && pe != nil && transientHTTPStatus(pe.StatusCode) {
 		return true
 	}
 	return false

--- a/plex/errors_test.go
+++ b/plex/errors_test.go
@@ -35,6 +35,11 @@ func TestIsTransientPlexErr(t *testing.T) {
 		{"econnrefused", syscall.ECONNREFUSED, true},
 		{"etimedout", syscall.ETIMEDOUT, true},
 		{"opaque", errors.New("plex search API returned status 401"), false},
+		{"http 401", &PlexHTTPError{StatusCode: 401, Op: "search"}, false},
+		{"http 503", &PlexHTTPError{StatusCode: 503, Op: "search"}, true},
+		{"http 502 wrapped", fmt.Errorf("wrap: %w", &PlexHTTPError{StatusCode: 502, Op: "x"}), true},
+		{"http 429", &PlexHTTPError{StatusCode: 429, Op: "rate"}, true},
+		{"http 408", &PlexHTTPError{StatusCode: 408, Op: "timeout"}, true},
 	}
 
 	for _, tt := range tests {

--- a/plex/pipeline_lock_transport.go
+++ b/plex/pipeline_lock_transport.go
@@ -1,0 +1,65 @@
+package plex
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// pipelineLockTransport serializes the entire Plex HTTP interaction: one in-flight
+// RoundTrip plus response body read/close at a time for this client.
+//
+// A mutex held only for RoundTrip is insufficient: net/http can return response headers
+// while the body is still streaming, so multiple goroutines (e.g. PLEX_MATCH_CONCURRENCY > 1)
+// would still interleave body reads on the same *http.Transport, which has been observed
+// in production as GC "bad pointer" / heap corruption under load (Docker/Kubernetes).
+type pipelineLockTransport struct {
+	mu   *sync.Mutex
+	base http.RoundTripper
+}
+
+func newPipelineLockTransport(mu *sync.Mutex, base http.RoundTripper) http.RoundTripper {
+	if mu == nil {
+		panic("pipelineLockTransport: nil mutex")
+	}
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &pipelineLockTransport{mu: mu, base: base}
+}
+
+func (t *pipelineLockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		t.mu.Unlock()
+		return nil, err
+	}
+	if resp == nil {
+		t.mu.Unlock()
+		return nil, nil
+	}
+	body := resp.Body
+	if body == nil {
+		body = io.NopCloser(strings.NewReader(""))
+	}
+	resp.Body = &pipelineUnlockOnClose{ReadCloser: body, mu: t.mu}
+	return resp, nil
+}
+
+type pipelineUnlockOnClose struct {
+	io.ReadCloser
+	mu   *sync.Mutex
+	once sync.Once
+}
+
+func (b *pipelineUnlockOnClose) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(func() {
+		if b.mu != nil {
+			b.mu.Unlock()
+		}
+	})
+	return err
+}

--- a/plex/pipeline_lock_transport_test.go
+++ b/plex/pipeline_lock_transport_test.go
@@ -1,0 +1,47 @@
+package plex
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestPipelineLockTransport_ReleasesLockOnBodyClose(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	base := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			ProtoMajor: 1,
+			ProtoMinor: 1,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("ok")),
+		}, nil
+	})
+
+	rt := newPipelineLockTransport(&mu, base)
+	req, err := http.NewRequest(http.MethodGet, "http://plex.test/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mu.TryLock() {
+		t.Fatal("mutex should still be held after RoundTrip (TryLock must fail)")
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !mu.TryLock() {
+		t.Fatal("mutex should be unlocked after body Close")
+	}
+	mu.Unlock()
+}

--- a/plex/playlist.go
+++ b/plex/playlist.go
@@ -79,9 +79,8 @@ func (c *Client) CreatePlaylist(ctx context.Context, title, description, trackUR
 	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK && resp.StatusCode != StatusCreated {
-		// Read the response body to get more details about the error
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("plex playlist creation API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, newPlexHTTPError(resp.StatusCode, "create playlist", body)
 	}
 
 	// Parse the JSON response to get the created playlist
@@ -152,7 +151,7 @@ func (c *Client) GetPlaylists(ctx context.Context) ([]PlexPlaylist, error) {
 			return nil, fmt.Errorf("read playlists body: %w", readErr)
 		}
 		if resp.StatusCode != StatusOK {
-			return nil, fmt.Errorf("plex playlists API returned status %d: %s", resp.StatusCode, string(body))
+			return nil, newPlexHTTPError(resp.StatusCode, "list playlists", body)
 		}
 
 		var container plexPlaylistsListContainer
@@ -214,9 +213,8 @@ func (c *Client) UpdatePlaylistMetadata(ctx context.Context, playlistID, title, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK && resp.StatusCode != StatusCreated {
-		// Read the response body to get more details about the error
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("plex playlist update API returned status %d: %s", resp.StatusCode, string(body))
+		return newPlexHTTPError(resp.StatusCode, "update playlist", body)
 	}
 
 	slog.Info(fmt.Sprintf("Successfully updated playlist metadata: %s (ID: %s)", title, playlistID))
@@ -247,9 +245,8 @@ func (c *Client) ClearPlaylist(ctx context.Context, playlistID string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK && resp.StatusCode != StatusNoContent {
-		// Read the response body to get more details about the error
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("plex playlist clear API returned status %d: %s", resp.StatusCode, string(body))
+		return newPlexHTTPError(resp.StatusCode, "clear playlist", body)
 	}
 
 	slog.Info(fmt.Sprintf("Successfully cleared playlist: %s", playlistID))
@@ -294,7 +291,7 @@ func (c *Client) GetPlaylistItems(ctx context.Context, playlistID string) ([]Ple
 			return nil, fmt.Errorf("read playlist items body: %w", readErr)
 		}
 		if resp.StatusCode != StatusOK {
-			return nil, fmt.Errorf("playlist items API status %d: %s", resp.StatusCode, string(body))
+			return nil, newPlexHTTPError(resp.StatusCode, "playlist items", body)
 		}
 
 		var container plexPlaylistItemsContainer

--- a/plex/search.go
+++ b/plex/search.go
@@ -3,6 +3,7 @@ package plex
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"net/http"
@@ -247,7 +248,8 @@ func (c *Client) searchByTitle(ctx context.Context, title, artist, sourceAlbum s
 	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
-		return nil, fmt.Errorf("plex search API returned status %d", resp.StatusCode)
+		b, _ := io.ReadAll(resp.Body)
+		return nil, newPlexHTTPError(resp.StatusCode, "search by title", b)
 	}
 
 	var searchResp PlexResponse
@@ -295,7 +297,8 @@ func (c *Client) searchByArtist(ctx context.Context, title, artist, sourceAlbum 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
-		return nil, fmt.Errorf("plex artist search API returned status %d", resp.StatusCode)
+		b, _ := io.ReadAll(resp.Body)
+		return nil, newPlexHTTPError(resp.StatusCode, "search by artist", b)
 	}
 
 	var searchResp PlexResponse
@@ -335,15 +338,20 @@ func (c *Client) searchByCombinedQuery(ctx context.Context, title, artist, sourc
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == StatusOK {
-		var searchResp PlexResponse
-		if err := decodePlexResponseXML(resp, &searchResp); err != nil {
-			slog.WarnContext(ctx, "combined Plex search returned OK but XML decode failed; trying other strategies",
-				"err", err, "query", query)
-		} else if track := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum); track != nil {
-			slog.Info(fmt.Sprintf("✅ searchByCombinedQuery: found match '%s' by '%s'", track.Title, track.Artist))
-			return track, nil
-		}
+	if resp.StatusCode != StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, newPlexHTTPError(resp.StatusCode, "combined search", b)
+	}
+
+	var searchResp PlexResponse
+	if err := decodePlexResponseXML(resp, &searchResp); err != nil {
+		slog.WarnContext(ctx, "combined Plex search returned OK but XML decode failed; trying other strategies",
+			"err", err, "query", query)
+		return nil, nil
+	}
+	if track := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum); track != nil {
+		slog.Info(fmt.Sprintf("✅ searchByCombinedQuery: found match '%s' by '%s'", track.Title, track.Artist))
+		return track, nil
 	}
 
 	return nil, nil
@@ -422,7 +430,8 @@ func (c *Client) searchEntireLibrary(ctx context.Context, title, artist, sourceA
 	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
-		return nil, fmt.Errorf("plex library API returned status %d", resp.StatusCode)
+		b, _ := io.ReadAll(resp.Body)
+		return nil, newPlexHTTPError(resp.StatusCode, "library all", b)
 	}
 
 	var libraryResp PlexResponse


### PR DESCRIPTION
## Summary

This pull request hardens the Plex client for containerized and highly concurrent runs (for example Kubernetes / Colima), where intermittent Plex or proxy errors and parallel HTTP were causing failures or rare runtime heap corruption.

## Changes

- **Typed HTTP errors** (`PlexHTTPError`): Plex responses with status **408, 429, and 5xx** are treated as **transient** by `isTransientPlexErr`, so search strategies can continue, playlist sync can soft-degrade where intended, and `GetServerID` retries a few times on transient errors.
- **Correct combined-search behavior**: non-200 responses no longer look like “no match”; they surface as errors and participate in transient handling.
- **Transport**: always clone `http.DefaultTransport` when possible and raise idle connection limits to reduce churn through NAT.
- **Pipeline lock transport**: one outbound Plex transaction (from `RoundTrip` through response body `Close`) at a time per client, including traffic from **plexgo**, so parallel `PLEX_MATCH_CONCURRENCY` workers cannot interleave body reads on the same `http.Client` (mitigates GC “bad pointer” crashes under load).
- **Tests**: extended transient-error tests, transport wiring tests, and a unit test for the pipeline lock.

## Tradeoff

Plex HTTP is serialized per client instance. With default rate limiting this is usually acceptable; unlimited RPS workloads may see lower parallel network throughput.

## Verification

- `go test ./...`
- `go test -race ./plex/...`
- `go vet ./...`

Made with [Cursor](https://cursor.com)