### PR TITLE
Match Plex per-track artist (originalTitle) for Various Artists

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -262,7 +262,7 @@ func (app *Application) displayMatchingResults(matchResults []plex.MatchResult, 
 
 		fmt.Printf("%3d. %s - %s: %s", i+1, result.SourceTrack.Artist, result.SourceTrack.Name, status)
 		if result.PlexTrack != nil {
-			fmt.Printf(" (Plex: %s - %s)", result.PlexTrack.Artist, result.PlexTrack.Title)
+			fmt.Printf(" (Plex: %s - %s)", result.PlexTrack.DisplayArtist(), result.PlexTrack.Title)
 		}
 		fmt.Println()
 	}

--- a/plex/client.go
+++ b/plex/client.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -68,16 +69,42 @@ type Client struct {
 	matchConfidencePercent *int
 }
 
-// PlexTrack represents a track from Plex
+// PlexTrack represents a track from Plex search and library API responses.
+// Artist is grandparentTitle (the album / library-hierarchy artist; often "Various Artists" on compilations).
+// OriginalTitle, when set, is the per-track artist (performer) — see Plex music Track attributes.
 type PlexTrack struct {
-	ID        string `xml:"ratingKey,attr"`
-	Title     string `xml:"title,attr"`
-	Artist    string `xml:"grandparentTitle,attr"`
-	Album     string `xml:"parentTitle,attr"`
-	Duration  int    `xml:"duration,attr"`
-	AddedAt   string `xml:"addedAt,attr"`
-	UpdatedAt string `xml:"updatedAt,attr"`
-	File      string `xml:"file,attr"`
+	ID            string `xml:"ratingKey,attr"`
+	Title         string `xml:"title,attr"`
+	Artist        string `xml:"grandparentTitle,attr"`
+	OriginalTitle string `xml:"originalTitle,attr"`
+	Album         string `xml:"parentTitle,attr"`
+	Duration      int    `xml:"duration,attr"`
+	AddedAt       string `xml:"addedAt,attr"`
+	UpdatedAt     string `xml:"updatedAt,attr"`
+	File          string `xml:"file,attr"`
+}
+
+// DisplayArtist returns a label for user-facing output: the track artist when set, else the album artist.
+func (t PlexTrack) DisplayArtist() string {
+	if s := strings.TrimSpace(t.OriginalTitle); s != "" {
+		return s
+	}
+	return t.Artist
+}
+
+// exactTitleAndArtistMatch reports whether titleLower and source artist (already lowercased) match this
+// track’s title and either the album artist (Artist) or the per-track originalTitle.
+func (t PlexTrack) exactTitleAndArtistMatch(titleLower, sourceArtistLower string) bool {
+	if titleLower != strings.ToLower(strings.TrimSpace(t.Title)) {
+		return false
+	}
+	if sourceArtistLower == strings.ToLower(strings.TrimSpace(t.Artist)) {
+		return true
+	}
+	if s := strings.TrimSpace(t.OriginalTitle); s != "" && sourceArtistLower == strings.ToLower(s) {
+		return true
+	}
+	return false
 }
 
 // PlexPlaylist represents a Plex playlist

--- a/plex/confidence.go
+++ b/plex/confidence.go
@@ -36,6 +36,44 @@ func intAbs(x int) int {
 	return x
 }
 
+// artistSimilarityTitleArtistForPlexField mirrors the song↔Plex artist comparisons in MatchTypeTitleArtist for one Plex artist string (album or track).
+func (c *Client) artistSimilarityTitleArtistForPlexField(song track.Track, plexField string) float64 {
+	plexLower := strings.ToLower(plexField)
+	artistSimilarity := c.calculateStringSimilarity(strings.ToLower(track.PrimaryListedArtist(song.Artist)), plexLower)
+	if full := strings.ToLower(strings.TrimSpace(song.Artist)); full != "" {
+		if sim := c.calculateStringSimilarity(full, plexLower); sim > artistSimilarity {
+			artistSimilarity = sim
+		}
+	}
+	if v := c.calculateStringSimilarity(
+		strings.ToLower(c.removeFeaturing(song.Artist)),
+		strings.ToLower(c.removeFeaturing(plexField)),
+	); v > artistSimilarity {
+		artistSimilarity = v
+	}
+	if v := c.calculateStringSimilarity(
+		strings.ToLower(c.removeFeaturing(track.PrimaryListedArtist(song.Artist))),
+		strings.ToLower(c.removeFeaturing(plexField)),
+	); v > artistSimilarity {
+		artistSimilarity = v
+	}
+	return artistSimilarity
+}
+
+// bestArtistSimilarityTitleArtist returns the best 0–1 match over grandparent and originalTitle.
+func (c *Client) bestArtistSimilarityTitleArtist(song track.Track, plex *PlexTrack) float64 {
+	var best float64
+	if s := strings.TrimSpace(plex.Artist); s != "" {
+		best = c.artistSimilarityTitleArtistForPlexField(song, s)
+	}
+	if s := strings.TrimSpace(plex.OriginalTitle); s != "" {
+		if v := c.artistSimilarityTitleArtistForPlexField(song, s); v > best {
+			best = v
+		}
+	}
+	return best
+}
+
 // calculateConfidence calculates a confidence score for the match
 func (c *Client) calculateConfidence(song track.Track, plexTrack *PlexTrack, matchType MatchKind) float64 {
 	if plexTrack == nil {
@@ -45,13 +83,7 @@ func (c *Client) calculateConfidence(song track.Track, plexTrack *PlexTrack, mat
 	switch matchType {
 	case MatchTypeTitleArtist:
 		titleSimilarity := c.calculateStringSimilarity(strings.ToLower(song.Name), strings.ToLower(plexTrack.Title))
-		plexArtistLower := strings.ToLower(plexTrack.Artist)
-		artistSimilarity := c.calculateStringSimilarity(strings.ToLower(track.PrimaryListedArtist(song.Artist)), plexArtistLower)
-		if full := strings.ToLower(strings.TrimSpace(song.Artist)); full != "" {
-			if sim := c.calculateStringSimilarity(full, plexArtistLower); sim > artistSimilarity {
-				artistSimilarity = sim
-			}
-		}
+		artistSimilarity := c.bestArtistSimilarityTitleArtist(song, plexTrack)
 
 		titleVariantPairs := []struct{ a, b string }{
 			{strings.ToLower(c.removeBrackets(song.Name)), strings.ToLower(c.removeBrackets(plexTrack.Title))},
@@ -66,21 +98,6 @@ func (c *Client) calculateConfidence(song track.Track, plexTrack *PlexTrack, mat
 			if sim > titleSimilarity {
 				titleSimilarity = sim
 			}
-		}
-
-		featuringArtistSimilarity := c.calculateStringSimilarity(
-			strings.ToLower(c.removeFeaturing(song.Artist)),
-			strings.ToLower(c.removeFeaturing(plexTrack.Artist)),
-		)
-		if featuringArtistSimilarity > artistSimilarity {
-			artistSimilarity = featuringArtistSimilarity
-		}
-		featuringPrimarySimilarity := c.calculateStringSimilarity(
-			strings.ToLower(c.removeFeaturing(track.PrimaryListedArtist(song.Artist))),
-			strings.ToLower(c.removeFeaturing(plexTrack.Artist)),
-		)
-		if featuringPrimarySimilarity > artistSimilarity {
-			artistSimilarity = featuringPrimarySimilarity
 		}
 
 		// Blend album only when both sides have album metadata (avoid punishing missing Plex parentTitle).

--- a/plex/search.go
+++ b/plex/search.go
@@ -95,7 +95,7 @@ func (c *Client) searchTrackWithArtist(ctx context.Context, song track.Track, ar
 				return nil, err
 			}
 			if tr != nil {
-				slog.Info(fmt.Sprintf("✅ SearchTrack: found match '%s' by '%s' using %s [%s tier]", tr.Title, tr.Artist, strategy.name, phase.tierLabel()))
+				slog.Info(fmt.Sprintf("✅ SearchTrack: found match '%s' by '%s' using %s [%s tier]", tr.Title, tr.DisplayArtist(), strategy.name, phase.tierLabel()))
 				return tr, nil
 			}
 		}
@@ -120,7 +120,7 @@ func (c *Client) searchTrackWithArtist(ctx context.Context, song track.Track, ar
 			}
 		}
 		if tr != nil {
-			slog.Info(fmt.Sprintf("✅ SearchTrack: found match '%s' by '%s' using full library search", tr.Title, tr.Artist))
+			slog.Info(fmt.Sprintf("✅ SearchTrack: found match '%s' by '%s' using full library search", tr.Title, tr.DisplayArtist()))
 			return tr, nil
 		}
 	}
@@ -261,12 +261,12 @@ func (c *Client) searchByTitle(ctx context.Context, title, artist, sourceAlbum s
 	slog.Info(fmt.Sprintf("🔍 searchByTitle: searching for '%s' by '%s', found %d results", title, artist, len(searchResp.Tracks)))
 	if len(searchResp.Tracks) > 0 && c.debug {
 		for i, track := range searchResp.Tracks {
-			c.debugLog("  Result %d: '%s' by '%s' (ID: %s)", i+1, track.Title, track.Artist, track.ID)
+			c.debugLog("  Result %d: '%s' by '%s' (ID: %s)", i+1, track.Title, track.DisplayArtist(), track.ID)
 		}
 	}
 	result := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum)
 	if result != nil {
-		slog.Info(fmt.Sprintf("✅ searchByTitle: found match '%s' by '%s'", result.Title, result.Artist))
+		slog.Info(fmt.Sprintf("✅ searchByTitle: found match '%s' by '%s'", result.Title, result.DisplayArtist()))
 	} else {
 		c.debugLog("❌ searchByTitle: no match found")
 	}
@@ -309,7 +309,7 @@ func (c *Client) searchByArtist(ctx context.Context, title, artist, sourceAlbum 
 	// Find best match among search results
 	result := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum)
 	if result != nil {
-		slog.Info(fmt.Sprintf("✅ searchByArtist: found match '%s' by '%s'", result.Title, result.Artist))
+		slog.Info(fmt.Sprintf("✅ searchByArtist: found match '%s' by '%s'", result.Title, result.DisplayArtist()))
 	}
 	return result, nil
 }
@@ -350,7 +350,7 @@ func (c *Client) searchByCombinedQuery(ctx context.Context, title, artist, sourc
 		return nil, nil
 	}
 	if track := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum); track != nil {
-		slog.Info(fmt.Sprintf("✅ searchByCombinedQuery: found match '%s' by '%s'", track.Title, track.Artist))
+		slog.Info(fmt.Sprintf("✅ searchByCombinedQuery: found match '%s' by '%s'", track.Title, track.DisplayArtist()))
 		return track, nil
 	}
 
@@ -443,7 +443,7 @@ func (c *Client) searchEntireLibrary(ctx context.Context, title, artist, sourceA
 	c.debugLog("🔍 searchEntireLibrary: searching for '%s' by '%s' in entire library (%d tracks)", title, artist, len(libraryResp.Tracks))
 	result := c.FindBestMatch(libraryResp.Tracks, title, artist, sourceAlbum)
 	if result != nil {
-		slog.Info(fmt.Sprintf("✅ searchEntireLibrary: found match '%s' by '%s' for search '%s' by '%s'", result.Title, result.Artist, title, artist))
+		slog.Info(fmt.Sprintf("✅ searchEntireLibrary: found match '%s' by '%s' for search '%s' by '%s'", result.Title, result.DisplayArtist(), title, artist))
 	} else {
 		slog.Info(fmt.Sprintf("❌ searchEntireLibrary: no match found for search '%s' by '%s'", title, artist))
 	}
@@ -485,6 +485,77 @@ func (c *Client) bestAlbumSimilarity(sourceAlbum, plexAlbum string) float64 {
 	return best
 }
 
+// artistMatchSimilarity returns the best 0–1 match between a source artist string and one Plex artist field
+// (album or track), using the same normalizations as FindBestMatch.
+func (c *Client) artistMatchSimilarity(artist, plexArtist string) float64 {
+	artistLower := strings.ToLower(strings.TrimSpace(artist))
+	trackArtist := strings.ToLower(strings.TrimSpace(plexArtist))
+	if trackArtist == "" {
+		return 0
+	}
+	artistSimilarity := c.calculateStringSimilarity(artistLower, trackArtist)
+
+	punctuationArtistLower := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(artist)))
+	punctuationTrackArtistLower := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(plexArtist)))
+	if v := c.calculateStringSimilarity(punctuationArtistLower, punctuationTrackArtistLower); v > artistSimilarity {
+		artistSimilarity = v
+	}
+	accentArtistLower := strings.ToLower(strings.TrimSpace(c.normalizeAccents(artist)))
+	accentTrackArtistLower := strings.ToLower(strings.TrimSpace(c.normalizeAccents(plexArtist)))
+	if v := c.calculateStringSimilarity(accentArtistLower, accentTrackArtistLower); v > artistSimilarity {
+		artistSimilarity = v
+	}
+	featuringArtistLower := strings.ToLower(strings.TrimSpace(c.removeFeaturing(artist)))
+	featuringTrackArtistLower := strings.ToLower(strings.TrimSpace(c.removeFeaturing(plexArtist)))
+	if v := c.calculateStringSimilarity(featuringArtistLower, featuringTrackArtistLower); v > artistSimilarity {
+		artistSimilarity = v
+	}
+	return artistSimilarity
+}
+
+// bestPlexTrackArtistSimilarity is the max artist similarity over grandparent (album) and originalTitle (track) when set.
+func (c *Client) bestPlexTrackArtistSimilarity(artist string, tr PlexTrack) float64 {
+	best := c.artistMatchSimilarity(artist, tr.Artist)
+	if s := strings.TrimSpace(tr.OriginalTitle); s != "" {
+		if v := c.artistMatchSimilarity(artist, s); v > best {
+			best = v
+		}
+	}
+	return best
+}
+
+// bestPlexTrackArtistSimilarityNormPunct matches FindBestMatchWithNormalizedPunctuation (normalized punctuation on both sides).
+func (c *Client) bestPlexTrackArtistSimilarityNormPunct(artist string, tr PlexTrack) float64 {
+	an := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(artist)))
+	sim := c.calculateStringSimilarity(an, strings.ToLower(strings.TrimSpace(c.normalizePunctuation(tr.Artist))))
+	if s := strings.TrimSpace(tr.OriginalTitle); s != "" {
+		if v := c.calculateStringSimilarity(an, strings.ToLower(strings.TrimSpace(c.normalizePunctuation(s)))); v > sim {
+			sim = v
+		}
+	}
+	return sim
+}
+
+// plexTrackNormPunctTitleArtistMatch returns true if normalized-punctuation title and artist match this track
+// (album artist and/or per-track originalTitle on the artist side).
+func (c *Client) plexTrackNormPunctTitleArtistMatch(tr PlexTrack, titleLower, artistLower string) bool {
+	nt := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(tr.Title)))
+	if titleLower != nt {
+		return false
+	}
+	na := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(tr.Artist)))
+	if artistLower == na {
+		return true
+	}
+	if s := strings.TrimSpace(tr.OriginalTitle); s != "" {
+		no := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(s)))
+		if artistLower == no {
+			return true
+		}
+	}
+	return false
+}
+
 // FindBestMatch finds the best matching track from search results. When sourceAlbum is non-empty,
 // album similarity is blended into the score so duplicate title/artist releases can be disambiguated.
 func (c *Client) FindBestMatch(tracks []PlexTrack, title, artist, sourceAlbum string) *PlexTrack {
@@ -501,16 +572,14 @@ func (c *Client) FindBestMatch(tracks []PlexTrack, title, artist, sourceAlbum st
 
 	var exactMatches []PlexTrack
 	for _, tr := range tracks {
-		trackTitle := strings.ToLower(strings.TrimSpace(tr.Title))
-		trackArtist := strings.ToLower(strings.TrimSpace(tr.Artist))
-		if titleLower == trackTitle && artistLower == trackArtist {
+		if tr.exactTitleAndArtistMatch(titleLower, artistLower) {
 			exactMatches = append(exactMatches, tr)
 		}
 	}
 	switch len(exactMatches) {
 	case 1:
 		t := exactMatches[0]
-		c.debugLog("✅ FindBestMatch: single exact match '%s' by '%s'", t.Title, t.Artist)
+		c.debugLog("✅ FindBestMatch: single exact match '%s' by '%s'", t.Title, t.DisplayArtist())
 		return &t
 	case 0:
 		// fall through to similarity scoring
@@ -539,44 +608,14 @@ func (c *Client) FindBestMatch(tracks []PlexTrack, title, artist, sourceAlbum st
 
 	for _, track := range tracks {
 		trackTitle := strings.ToLower(strings.TrimSpace(track.Title))
-		trackArtist := strings.ToLower(strings.TrimSpace(track.Artist))
 
 		// Calculate similarity scores with original titles
 		titleSimilarity := c.calculateStringSimilarity(titleLower, trackTitle)
-		artistSimilarity := c.calculateStringSimilarity(artistLower, trackArtist)
+		artistSimilarity := c.bestPlexTrackArtistSimilarity(artist, track)
 
-		c.debugLog("🔍 FindBestMatch: '%s' by '%s' -> '%s' by '%s'", title, artist, track.Title, track.Artist)
+		c.debugLog("🔍 FindBestMatch: '%s' by '%s' -> '%s' by '%s'", title, artist, track.Title, track.DisplayArtist())
 		c.debugLog("   Original title similarity: %s ('%s' vs '%s')", formatConfidencePercent(titleSimilarity), titleLower, trackTitle)
-		c.debugLog("   Original artist similarity: %s ('%s' vs '%s')", formatConfidencePercent(artistSimilarity), artistLower, trackArtist)
-
-		// Also try with normalized punctuation for artist matching
-		punctuationArtistLower := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(artist)))
-		punctuationTrackArtistLower := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(track.Artist)))
-		punctuationArtistSimilarity := c.calculateStringSimilarity(punctuationArtistLower, punctuationTrackArtistLower)
-
-		// Also try with accent normalization for artist matching
-		accentArtistLower := strings.ToLower(strings.TrimSpace(c.normalizeAccents(artist)))
-		accentTrackArtistLower := strings.ToLower(strings.TrimSpace(c.normalizeAccents(track.Artist)))
-		accentArtistSimilarity := c.calculateStringSimilarity(accentArtistLower, accentTrackArtistLower)
-
-		// Also try with featuring removed for artist matching
-		featuringArtistLower := strings.ToLower(strings.TrimSpace(c.removeFeaturing(artist)))
-		featuringTrackArtistLower := strings.ToLower(strings.TrimSpace(c.removeFeaturing(track.Artist)))
-		featuringArtistSimilarity := c.calculateStringSimilarity(featuringArtistLower, featuringTrackArtistLower)
-
-		// Use the better artist similarity
-		if punctuationArtistSimilarity > artistSimilarity {
-			c.debugLog("   Using normalized artist similarity: %s (was %s)", formatConfidencePercent(punctuationArtistSimilarity), formatConfidencePercent(artistSimilarity))
-			artistSimilarity = punctuationArtistSimilarity
-		}
-		if accentArtistSimilarity > artistSimilarity {
-			c.debugLog("   Using accent-normalized artist similarity: %s (was %s)", formatConfidencePercent(accentArtistSimilarity), formatConfidencePercent(artistSimilarity))
-			artistSimilarity = accentArtistSimilarity
-		}
-		if featuringArtistSimilarity > artistSimilarity {
-			c.debugLog("   Using featuring-removed artist similarity: %s (was %s)", formatConfidencePercent(featuringArtistSimilarity), formatConfidencePercent(artistSimilarity))
-			artistSimilarity = featuringArtistSimilarity
-		}
+		c.debugLog("   Best artist similarity (album + track fields): %s", formatConfidencePercent(artistSimilarity))
 
 		// Also try with cleaned titles (without brackets) for better matching
 		cleanTitleLower := strings.ToLower(strings.TrimSpace(c.removeBrackets(title)))
@@ -704,12 +743,12 @@ func (c *Client) FindBestMatch(tracks []PlexTrack, title, artist, sourceAlbum st
 			// Check if this is a "Various Artists" compilation album case
 			if strings.ToLower(strings.TrimSpace(track.Artist)) == "various artists" {
 				c.debugLog("🎵 FindBestMatch: allowing 'Various Artists' compilation match '%s' by '%s' (title: %s > 90%%, artist: %s < 30%% but is Various Artists)",
-					track.Title, track.Artist, formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
+					track.Title, track.DisplayArtist(), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
 				// Don't skip this match - it's a valid compilation album case
 			} else {
 				// Skip this match - title is very similar but artist is too different
 				c.debugLog("🚫 FindBestMatch: rejecting '%s' by '%s' (title: %s > 90%%, artist: %s < 30%%)",
-					track.Title, track.Artist, formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
+					track.Title, track.DisplayArtist(), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
 				continue
 			}
 		}
@@ -720,12 +759,12 @@ func (c *Client) FindBestMatch(tracks []PlexTrack, title, artist, sourceAlbum st
 			// Check if this is a "Various Artists" compilation album case
 			if strings.ToLower(strings.TrimSpace(track.Artist)) == "various artists" {
 				c.debugLog("🎵 FindBestMatch: allowing 'Various Artists' compilation match '%s' by '%s' (title: %s > 70%%, artist: %s < 20%% but is Various Artists)",
-					track.Title, track.Artist, formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
+					track.Title, track.DisplayArtist(), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
 				// Don't skip this match - it's a valid compilation album case
 			} else {
 				// Skip this match - title is similar but artist is too different
 				c.debugLog("🚫 FindBestMatch: rejecting '%s' by '%s' (title: %s > 70%%, artist: %s < 20%%)",
-					track.Title, track.Artist, formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
+					track.Title, track.DisplayArtist(), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
 				continue
 			}
 		}
@@ -758,18 +797,18 @@ func (c *Client) FindBestMatch(tracks []PlexTrack, title, artist, sourceAlbum st
 			bestAlbumSimilarity = albumSimilarity
 			if prevBest == nil || score > oldScore+scoreEqEps {
 				c.debugLog("📈 FindBestMatch: new best match '%s' by '%s' (score: %s > %s, title: %s, artist: %s)",
-					track.Title, track.Artist, formatConfidencePercent(score), formatConfidencePercent(oldScore), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
+					track.Title, track.DisplayArtist(), formatConfidencePercent(score), formatConfidencePercent(oldScore), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity))
 			} else {
-				c.debugLog("🎯 FindBestMatch: tie-breaker '%s' by '%s' (score: %s)", track.Title, track.Artist, formatConfidencePercent(score))
+				c.debugLog("🎯 FindBestMatch: tie-breaker '%s' by '%s' (score: %s)", track.Title, track.DisplayArtist(), formatConfidencePercent(score))
 			}
 		} else {
 			c.debugLog("⏭️  FindBestMatch: skipping '%s' by '%s' (score: %s, current best: %s)",
-				track.Title, track.Artist, formatConfidencePercent(score), formatConfidencePercent(bestScore))
+				track.Title, track.DisplayArtist(), formatConfidencePercent(score), formatConfidencePercent(bestScore))
 		}
 
 		// Perfect title+artist: return immediately only when album is not used for disambiguation.
 		if !useAlbumInScore && titleSimilarity == 1.0 && artistSimilarity == 1.0 {
-			c.debugLog("🎯 FindBestMatch: perfect match found '%s' by '%s'", track.Title, track.Artist)
+			c.debugLog("🎯 FindBestMatch: perfect match found '%s' by '%s'", track.Title, track.DisplayArtist())
 			trackCopy := track
 			return &trackCopy
 		}
@@ -779,7 +818,7 @@ func (c *Client) FindBestMatch(tracks []PlexTrack, title, artist, sourceAlbum st
 	minScore := c.minMatchScore()
 	if bestScore >= minScore {
 		slog.Info(fmt.Sprintf("✅ FindBestMatch: FINAL RESULT - returning match '%s' by '%s' (score: %s >= %s) for search '%s' by '%s'",
-			bestMatch.Title, bestMatch.Artist, formatConfidencePercent(bestScore), formatConfidencePercent(minScore), title, artist))
+			bestMatch.Title, bestMatch.DisplayArtist(), formatConfidencePercent(bestScore), formatConfidencePercent(minScore), title, artist))
 		return bestMatch
 	}
 
@@ -806,18 +845,14 @@ func (c *Client) FindBestMatchWithNormalizedPunctuation(tracks []PlexTrack, titl
 
 	var exactMatches []PlexTrack
 	for _, tr := range tracks {
-		normalizedTrackTitle := c.normalizePunctuation(tr.Title)
-		normalizedTrackArtist := c.normalizePunctuation(tr.Artist)
-		trackTitle := strings.ToLower(strings.TrimSpace(normalizedTrackTitle))
-		trackArtist := strings.ToLower(strings.TrimSpace(normalizedTrackArtist))
-		if titleLower == trackTitle && artistLower == trackArtist {
+		if c.plexTrackNormPunctTitleArtistMatch(tr, titleLower, artistLower) {
 			exactMatches = append(exactMatches, tr)
 		}
 	}
 	switch len(exactMatches) {
 	case 1:
 		t := exactMatches[0]
-		slog.Info(fmt.Sprintf("✅ FindBestMatchWithNormalizedPunctuation: single exact match '%s' by '%s'", t.Title, t.Artist))
+		slog.Info(fmt.Sprintf("✅ FindBestMatchWithNormalizedPunctuation: single exact match '%s' by '%s'", t.Title, t.DisplayArtist()))
 		return &t
 	case 0:
 	default:
@@ -844,13 +879,10 @@ func (c *Client) FindBestMatchWithNormalizedPunctuation(tracks []PlexTrack, titl
 
 	for _, track := range tracks {
 		normalizedTrackTitle := c.normalizePunctuation(track.Title)
-		normalizedTrackArtist := c.normalizePunctuation(track.Artist)
-
 		trackTitle := strings.ToLower(strings.TrimSpace(normalizedTrackTitle))
-		trackArtist := strings.ToLower(strings.TrimSpace(normalizedTrackArtist))
 
 		titleSimilarity := c.calculateStringSimilarity(titleLower, trackTitle)
-		artistSimilarity := c.calculateStringSimilarity(artistLower, trackArtist)
+		artistSimilarity := c.bestPlexTrackArtistSimilarityNormPunct(artist, track)
 
 		albumSimilarity := 0.0
 		if useAlbumInScore {
@@ -865,15 +897,23 @@ func (c *Client) FindBestMatchWithNormalizedPunctuation(tracks []PlexTrack, titl
 		}
 
 		if titleSimilarity > 0.9 && artistSimilarity < 0.3 {
-			slog.Info(fmt.Sprintf("🚫 FindBestMatchWithNormalizedPunctuation: rejecting '%s' by '%s' (title: %s > 90%%, artist: %s < 30%%)",
-				track.Title, track.Artist, formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity)))
-			continue
+			if strings.ToLower(strings.TrimSpace(track.Artist)) == "various artists" {
+				// Match FindBestMatch: allow VA compilations
+			} else {
+				slog.Info(fmt.Sprintf("🚫 FindBestMatchWithNormalizedPunctuation: rejecting '%s' by '%s' (title: %s > 90%%, artist: %s < 30%%)",
+					track.Title, track.DisplayArtist(), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity)))
+				continue
+			}
 		}
 
 		if titleSimilarity > 0.7 && artistSimilarity < 0.2 {
-			slog.Info(fmt.Sprintf("🚫 FindBestMatchWithNormalizedPunctuation: rejecting '%s' by '%s' (title: %s > 70%%, artist: %s < 20%%)",
-				track.Title, track.Artist, formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity)))
-			continue
+			if strings.ToLower(strings.TrimSpace(track.Artist)) == "various artists" {
+				// allow VA
+			} else {
+				slog.Info(fmt.Sprintf("🚫 FindBestMatchWithNormalizedPunctuation: rejecting '%s' by '%s' (title: %s > 70%%, artist: %s < 20%%)",
+					track.Title, track.DisplayArtist(), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity)))
+				continue
+			}
 		}
 
 		pick := false
@@ -901,11 +941,11 @@ func (c *Client) FindBestMatchWithNormalizedPunctuation(tracks []PlexTrack, titl
 			bestArtistSimilarity = artistSimilarity
 			bestAlbumSimilarity = albumSimilarity
 			slog.Info(fmt.Sprintf("📈 FindBestMatchWithNormalizedPunctuation: new best match '%s' by '%s' (score: %s, title: %s, artist: %s)",
-				track.Title, track.Artist, formatConfidencePercent(score), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity)))
+				track.Title, track.DisplayArtist(), formatConfidencePercent(score), formatConfidencePercent(titleSimilarity), formatConfidencePercent(artistSimilarity)))
 		}
 
 		if !useAlbumInScore && titleSimilarity == 1.0 && artistSimilarity == 1.0 {
-			slog.Info(fmt.Sprintf("🎯 FindBestMatchWithNormalizedPunctuation: perfect match found '%s' by '%s'", track.Title, track.Artist))
+			slog.Info(fmt.Sprintf("🎯 FindBestMatchWithNormalizedPunctuation: perfect match found '%s' by '%s'", track.Title, track.DisplayArtist()))
 			trackCopy := track
 			return &trackCopy
 		}
@@ -914,7 +954,7 @@ func (c *Client) FindBestMatchWithNormalizedPunctuation(tracks []PlexTrack, titl
 	minScore := c.minMatchScore()
 	if bestScore >= minScore {
 		slog.Info(fmt.Sprintf("✅ FindBestMatchWithNormalizedPunctuation: returning match '%s' by '%s' (score: %s >= %s)",
-			bestMatch.Title, bestMatch.Artist, formatConfidencePercent(bestScore), formatConfidencePercent(minScore)))
+			bestMatch.Title, bestMatch.DisplayArtist(), formatConfidencePercent(bestScore), formatConfidencePercent(minScore)))
 		return bestMatch
 	}
 

--- a/plex/search_test.go
+++ b/plex/search_test.go
@@ -1,6 +1,100 @@
 package plex
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/grrywlsn/plexify/track"
+)
+
+func TestPlexTrack_DisplayArtist(t *testing.T) {
+	t.Parallel()
+	va := PlexTrack{Artist: "Various Artists", OriginalTitle: "Whethan"}
+	if g, w := va.DisplayArtist(), "Whethan"; g != w {
+		t.Fatalf("DisplayArtist: got %q, want %q", g, w)
+	}
+	if p := (PlexTrack{Artist: "ABBA"}); p.DisplayArtist() != "ABBA" {
+		t.Fatal("expected grandparent when OriginalTitle empty")
+	}
+}
+
+func TestPlexTrack_exactTitleAndArtistMatch(t *testing.T) {
+	t.Parallel()
+	album := "Fifty Shades Freed"
+	tr := PlexTrack{Title: "High", Artist: "Various Artists", OriginalTitle: "Whethan", Album: album}
+	if !tr.exactTitleAndArtistMatch("high", "whethan") {
+		t.Fatal("expected match against originalTitle")
+	}
+	if tr.exactTitleAndArtistMatch("other", "whethan") {
+		t.Fatal("title must not match")
+	}
+}
+
+func TestFindBestMatch_variousArtistsOriginalTitle(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	album := "Fifty Shades Freed: The Final Chapter: Original Motion Picture Soundtrack"
+	tracks := []PlexTrack{{
+		ID:            "1",
+		Title:         "High",
+		Artist:        "Various Artists",
+		OriginalTitle: "Whethan",
+		Album:         album,
+	}}
+	got := c.FindBestMatch(tracks, "High", "Whethan", album)
+	if got == nil || got.ID != "1" {
+		t.Fatalf("expected match, got %v", got)
+	}
+}
+
+func TestFindBestMatch_variousArtistsTwoCandidatesOriginalTitlePicks(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	album := "Fifty Shades Freed: The Final Chapter: Original Motion Picture Soundtrack"
+	tracks := []PlexTrack{
+		{ID: "a", Title: "High", Artist: "Various Artists", OriginalTitle: "Wrong Artist", Album: album},
+		{ID: "b", Title: "High", Artist: "Various Artists", OriginalTitle: "Whethan", Album: album},
+	}
+	got := c.FindBestMatch(tracks, "High", "Whethan", album)
+	if got == nil || got.ID != "b" {
+		t.Fatalf("expected id b, got %v", got)
+	}
+}
+
+func TestFindBestMatch_variousArtistsOriginalTitleCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	album := "Fifty Shades Freed: The Final Chapter: Original Motion Picture Soundtrack"
+	tracks := []PlexTrack{{
+		ID: "1", Title: "High", Artist: "Various Artists", OriginalTitle: "Whethan", Album: album,
+	}}
+	if c.FindBestMatch(tracks, "High", "Whethan", album) == nil {
+		t.Fatal("expected match with canonical case")
+	}
+}
+
+func TestFindBestMatchWithNormalizedPunctuation_variousArtistsOriginalTitle(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	album := "Fifty Shades Freed: The Final Chapter: Original Motion Picture Soundtrack"
+	tracks := []PlexTrack{{
+		ID: "1", Title: "High", Artist: "Various Artists", OriginalTitle: "Whethan", Album: album,
+	}}
+	if got := c.FindBestMatchWithNormalizedPunctuation(tracks, "High", "Whethan", album); got == nil {
+		t.Fatal("expected match")
+	}
+}
+
+func TestCalculateConfidence_variousArtistsOriginalTitle(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	album := "Fifty Shades Freed: The Final Chapter: Original Motion Picture Soundtrack"
+	song := track.Track{Name: "High", Artist: "Whethan", Album: album}
+	plexTr := &PlexTrack{Title: "High", Artist: "Various Artists", OriginalTitle: "Whethan", Album: album}
+	conf := c.calculateConfidence(song, plexTr, MatchTypeTitleArtist)
+	if min := c.minMatchScore(); conf < min {
+		t.Fatalf("expected confidence >= %g, got %g", min, conf)
+	}
+}
 
 func TestIndexedTrackSearchStrategies_order(t *testing.T) {
 	c := &Client{}

--- a/plex/xml_response_test.go
+++ b/plex/xml_response_test.go
@@ -37,6 +37,34 @@ func TestDecodePlexResponseXML_ValidSearchPayload(t *testing.T) {
 	}
 }
 
+func TestDecodePlexResponseXML_TrackWithOriginalTitle(t *testing.T) {
+	t.Parallel()
+
+	const doc = `<?xml version="1.0" encoding="UTF-8"?>` + "\n" +
+		`<MediaContainer size="1">` +
+		`<Track ratingKey="99" title="High" grandparentTitle="Various Artists" originalTitle="Whethan" parentTitle="Fifty Shades"/>` +
+		`</MediaContainer>`
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(doc)),
+	}
+	var got PlexResponse
+	if err := decodePlexResponseXML(resp, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Tracks) != 1 {
+		t.Fatalf("tracks: got %d, want 1", len(got.Tracks))
+	}
+	tr := got.Tracks[0]
+	if tr.Title != "High" || tr.Artist != "Various Artists" || tr.OriginalTitle != "Whethan" || tr.Album != "Fifty Shades" {
+		t.Fatalf("unexpected decode: %#v", tr)
+	}
+	if tr.DisplayArtist() != "Whethan" {
+		t.Fatalf("DisplayArtist: got %q", tr.DisplayArtist())
+	}
+}
+
 func TestDecodePlexResponseXML_ValidServerInfo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Plex maps **album artist** to `grandparentTitle` and **track/performer artist** to `originalTitle` (common on *Various Artists* soundtracks and compilations). Plexify only used `grandparentTitle`, so source artist "Whethan" was compared to "Various Artists" and often failed to match or scored below the confidence floor.

## Changes

- **`PlexTrack`**: add `OriginalTitle` (`originalTitle`); document `Artist` vs per-track artist.
- **Matching**: take the **max** of artist-similarity over `Artist` and `originalTitle` in `FindBestMatch`, `FindBestMatchWithNormalizedPunctuation` (incl. exact match paths), and `calculateConfidence` for `MatchTypeTitleArtist`.
- **UI/logs**: `DisplayArtist()` prefers `originalTitle` when set; use in `slog` success lines, debug output, and the app’s match table (`Plex: …` column).
- **Tests**: VA + `originalTitle` cases, disambiguation, confidence, norm-punct path, XML decode.

## Testing

- `go test ./...` passes locally.


Made with [Cursor](https://cursor.com)