### PR TITLE
Playlist diff: best-matching Plex artist label for Various Artists

### DIFF
--- a/plex/playlist_diff.go
+++ b/plex/playlist_diff.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/grrywlsn/plexify/internal/cliutil"
+	"github.com/grrywlsn/plexify/track"
 	"golang.org/x/term"
 )
 
@@ -230,18 +232,20 @@ func fprintPlaylistDiff(w io.Writer, view PlaylistDiffView, useColor, outerBanne
 			src := ent.MatchResult.SourceTrack
 			pt := ent.MatchResult.PlexTrack
 			printLine(ansiGreen+ansiBold, fmt.Sprintf("+ %s: ", sourceServiceDisplayName)+formatArtistTitle(src.Artist, src.Name))
-			printLine(ansiGreen, "+ plex:         "+formatArtistTitle(pt.Artist, pt.Title)+fmt.Sprintf(" (confidence: %s)", formatConfidencePercent(ent.MatchResult.Confidence)))
+			plexArtist := plexArtistForPlaylistDiffLine(src, pt)
+			printLine(ansiGreen, "+ plex:         "+formatArtistTitle(plexArtist, pt.Title)+fmt.Sprintf(" (confidence: %s)", formatConfidencePercent(ent.MatchResult.Confidence)))
 		case PlaylistDiffRemove:
 			pt := &view.Old[op.OldIdx]
-			printLine(ansiRed+ansiBold, "- plex:         "+formatArtistTitle(pt.Artist, pt.Title))
+			printLine(ansiRed+ansiBold, "- plex:         "+formatArtistTitle(pt.DisplayArtist(), pt.Title))
 		case PlaylistDiffChange:
 			oldTr := &view.Old[op.OldIdx]
 			ent := view.Desired[op.NewIdx]
 			src := ent.MatchResult.SourceTrack
 			newPt := ent.MatchResult.PlexTrack
-			printLine(ansiYellow+ansiBold, "~ was (plex):    "+formatArtistTitle(oldTr.Artist, oldTr.Title))
+			printLine(ansiYellow+ansiBold, "~ was (plex):    "+formatArtistTitle(oldTr.DisplayArtist(), oldTr.Title))
 			printLine(ansiYellow, "~ now (source): "+formatArtistTitle(src.Artist, src.Name))
-			printLine(ansiYellow, "~ now (plex):   "+formatArtistTitle(newPt.Artist, newPt.Title)+fmt.Sprintf(" (confidence: %s)", formatConfidencePercent(ent.MatchResult.Confidence)))
+			nowPlexArtist := plexArtistForPlaylistDiffLine(src, newPt)
+			printLine(ansiYellow, "~ now (plex):   "+formatArtistTitle(nowPlexArtist, newPt.Title)+fmt.Sprintf(" (confidence: %s)", formatConfidencePercent(ent.MatchResult.Confidence)))
 		}
 		fmt.Fprintln(w, "")
 	}
@@ -249,4 +253,39 @@ func fprintPlaylistDiff(w io.Writer, view PlaylistDiffView, useColor, outerBanne
 
 func formatArtistTitle(artist, title string) string {
 	return fmt.Sprintf("%s - %s", artist, title)
+}
+
+// plexArtistForPlaylistDiffLine picks the Plex grandparent (album) or per-track (originalTitle) name
+// to show on diff lines by comparing each field against the source track’s search artist candidates,
+// using the same artistMatchSimilarity logic as FindBestMatch. When only one field is set, that
+// value is used. For rows without a source (e.g. old playlist items), use PlexTrack.DisplayArtist.
+func plexArtistForPlaylistDiffLine(src track.Track, tr *PlexTrack) string {
+	if tr == nil {
+		return ""
+	}
+	a := strings.TrimSpace(tr.Artist)
+	ot := strings.TrimSpace(tr.OriginalTitle)
+	if ot == "" {
+		return a
+	}
+	if a == "" {
+		return ot
+	}
+	var c Client
+	bestA := 0.0
+	for _, cand := range src.PlexSearchArtistCandidates() {
+		if s := c.artistMatchSimilarity(cand, a); s > bestA {
+			bestA = s
+		}
+	}
+	bestOt := 0.0
+	for _, cand := range src.PlexSearchArtistCandidates() {
+		if s := c.artistMatchSimilarity(cand, ot); s > bestOt {
+			bestOt = s
+		}
+	}
+	if bestOt >= bestA {
+		return ot
+	}
+	return a
 }

--- a/plex/playlist_diff_test.go
+++ b/plex/playlist_diff_test.go
@@ -118,6 +118,47 @@ func TestFprintPlaylistDiff_noColor(t *testing.T) {
 	}
 }
 
+func TestPlexArtistForPlaylistDiffLine_variousArtists(t *testing.T) {
+	t.Parallel()
+	src := track.Track{Artist: "Khalid", Name: "Love Lies"}
+	tr := &PlexTrack{Artist: "Various Artists", OriginalTitle: "Khalid", Title: "Love Lies"}
+	if got := plexArtistForPlaylistDiffLine(src, tr); got != "Khalid" {
+		t.Fatalf("expected per-track label when it matches source best, got %q", got)
+	}
+}
+
+func TestPlexArtistForPlaylistDiffLine_albumArtistWhenStronger(t *testing.T) {
+	t.Parallel()
+	src := track.Track{Artist: "ABBA", Name: "Dancing Queen"}
+	tr := &PlexTrack{Artist: "ABBA", OriginalTitle: "Guest", Title: "Dancing Queen"}
+	if got := plexArtistForPlaylistDiffLine(src, tr); got != "ABBA" {
+		t.Fatalf("expected album artist when it matches better, got %q", got)
+	}
+}
+
+func TestFprintPlaylistDiff_plexLineUsesBestArtistField(t *testing.T) {
+	var b strings.Builder
+	desired := []PlaylistDesiredEntry{
+		{
+			MatchResult: MatchResult{
+				SourceTrack: track.Track{Artist: "Khalid", Name: "Love Lies"},
+				PlexTrack:   &PlexTrack{ID: "1", Artist: "Various Artists", OriginalTitle: "Khalid", Title: "Love Lies"},
+				MatchType:   MatchTypeTitleArtist,
+				Confidence:  0.93,
+			},
+		},
+	}
+	view := NewPlaylistDiffView("Test", nil, desired)
+	FprintPlaylistDiff(&b, view, false)
+	out := b.String()
+	if strings.Contains(out, "Various Artists - Love Lies") {
+		t.Fatalf("expected plex line to prefer matching track artist, got: %s", out)
+	}
+	if !strings.Contains(out, "Khalid - Love Lies") {
+		t.Fatalf("expected Khalid on plex line, got: %s", out)
+	}
+}
+
 func TestFormatConfidencePercent(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Problem

The playlist changes summary showed `Various Artists - …` on the `+ plex:` line even when the match was driven by the per-track artist (`originalTitle`), which was confusing next to the source line (e.g. `Khalid - Love Lies`).

## Solution

- **`plexArtistForPlaylistDiffLine`**: compare each of `Artist` (grandparent) and `OriginalTitle` against the source track’s `PlexSearchArtistCandidates()` using the same `artistMatchSimilarity` as `FindBestMatch`, then show whichever field matches the source best.
- **Add** and **~ now (plex):** use that label.
- **Remove** and **~ was (plex):** use `DisplayArtist()` when there is no source row (prefer track artist when set).

## Tests

- Unit tests for VA + `originalTitle`, album-artist-wins case, and `FprintPlaylistDiff` output.

`go test ./...` passes.


Made with [Cursor](https://cursor.com)