### PR TITLE
feat: auto-add missing release groups to Lidarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ Boolean variables treat `1`, `true`, `yes`, and `on` (case-insensitive) as true;
 | `PLEXIFY_FAST_SEARCH` | off | Skip full-library scan (`/library/sections/{id}/all`); use indexed `/search` only. |
 | `PLEX_SKIP_FULL_LIBRARY_SEARCH` | off | Alias for `PLEXIFY_FAST_SEARCH`. |
 | `PLEXIFY_EXACT_MATCHES_ONLY` | off | Only the first search strategy (raw title/artist); no normalizations and no full-library scan. |
+| `LIDARR_URL` | empty | **Optional.** Lidarr base URL (e.g. `http://host:8686` or `https://lidarr:8686`). If set, `LIDARR_TOKEN` is also required. Used to add missing tracks that have a MusicBrainz release group id. |
+| `LIDARR_TOKEN` | empty | **Optional.** Lidarr API key (`Settings` → `Security` → **API Key**). Required when `LIDARR_URL` is set. |
+| `LIDARR_INSECURE_SKIP_VERIFY` | off | If true, skip TLS certificate verification for Lidarr HTTPS (e.g. self-signed). Default is to **verify** certificates. |
 | `NO_COLOR` | _(unset)_ | If set to any non-empty value, playlist diff output disables ANSI color when stdout is a terminal. |
 
 Environment variables, a `.env` file, or flags (same names, e.g. `-MUSIC_SOCIAL_URL=...`) are all supported.
@@ -184,6 +187,8 @@ Environment variables, a `.env` file, or flags (same names, e.g. `-MUSIC_SOCIAL_
 - `-plex-fast-search` — same as `PLEXIFY_FAST_SEARCH=true` (no `/all` fallback)
 - `-exact-matches-only` — same as `PLEXIFY_EXACT_MATCHES_ONLY=true` (first search strategy only; no `/all`)
 - `-plex-max-rps=N` — overrides `PLEX_MAX_REQUESTS_PER_SECOND` (`0` = unlimited)
+- `-LIDARR_URL=...` / `-LIDARR_TOKEN=...` — optional; same as env (both required to enable Lidarr)
+- `-lidarr-insecure-skip-verify` — same as `LIDARR_INSECURE_SKIP_VERIFY=true`
 - `-version` — print version and exit
 
 ```bash
@@ -293,6 +298,8 @@ Tracks not found in Plex library (5 total):
 ```
 
 **Note:** The missing-tracks section lists ISRC when known. When the source API includes `musicbrainz.release_group_gid`, a **MusicBrainz release group** line links to that release group; otherwise, when only a recording MBID is present, **MusicBrainz ID** links to the recording. When there is **no** MBID but the API includes a **Spotify album** (`spotify.album_uri`) or **Apple Music album id** (`apple_music.album_id`), an **Add to MusicBrainz** line links to [Harmony](https://harmony.pulsewidth.org.uk/) in the same form as music-social’s admin (Spotify album preferred over Apple when both are present; Apple URLs use the `us` storefront).
+
+**Lidarr:** If you set both `LIDARR_URL` and `LIDARR_TOKEN`, Plexify will **deduplicate** by release group, then for each missing track that has a **MusicBrainz release group** id, ask Lidarr to add that release group (if it is not already in Lidarr) and start a **search for the release**. For new artists, Lidarr needs a root folder path and quality/metadata profile ids; Plexify fills these from your Lidarr instance (first **root folder** from Settings → Media Management, using that folder’s default profiles when set, otherwise the first quality and metadata profile). In `PLEXIFY_DRY_RUN` mode, Plexify only prints which release group ids it would send to Lidarr; it does not call the Lidarr API. Failures from Lidarr are logged; they do not stop the rest of the run.
 
 ## Matching Order and Rules
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 type Config struct {
 	MusicSocial MusicSocialConfig
 	Plex        PlexConfig
+	Lidarr      LidarrConfig
 }
 
 // MusicSocialConfig holds HTTP API configuration for music-social.com (or a compatible host via MUSIC_SOCIAL_URL).
@@ -41,6 +42,18 @@ type PlexConfig struct {
 	MaxRequestsPerSecond float64
 	// MatchConfidencePercent is the minimum combined title/artist match score (0–100) required to accept a Plex track. Default 80 (PLEXIFY_MATCH_CONFIDENCE_PERCENT).
 	MatchConfidencePercent int
+}
+
+// LidarrConfig holds Lidarr API settings for auto-adding missing MusicBrainz release groups. Both URL and Token must be set to enable; see LidarrEnabled.
+type LidarrConfig struct {
+	URL                string
+	Token              string
+	InsecureSkipVerify bool // LIDARR_INSECURE_SKIP_VERIFY: skip TLS verify for HTTPS (e.g. self-signed)
+}
+
+// LidarrEnabled is true when Lidarr integration should run (both URL and non-empty API token are set).
+func (c *Config) LidarrEnabled() bool {
+	return strings.TrimSpace(c.Lidarr.URL) != "" && strings.TrimSpace(c.Lidarr.Token) != ""
 }
 
 // Load loads configuration following the specified order:
@@ -105,6 +118,12 @@ func (c *Config) initializeDefaults() {
 		MaxRequestsPerSecond:   4,
 		MatchConfidencePercent: DefaultMatchConfidencePercent,
 	}
+
+	c.Lidarr = LidarrConfig{
+		URL:                "",
+		Token:              "",
+		InsecureSkipVerify: false,
+	}
 }
 
 // DefaultMatchConfidencePercent is the default minimum match score (whole percent) when PLEXIFY_MATCH_CONFIDENCE_PERCENT is unset.
@@ -157,6 +176,19 @@ func (c *Config) loadFromOSEnv() {
 	if f, ok := parseFloatEnv("PLEX_MAX_REQUESTS_PER_SECOND"); ok {
 		c.Plex.MaxRequestsPerSecond = f
 	}
+	c.loadLidarrFromEnv()
+}
+
+func (c *Config) loadLidarrFromEnv() {
+	if value := os.Getenv("LIDARR_URL"); value != "" {
+		c.Lidarr.URL = value
+	}
+	if value := os.Getenv("LIDARR_TOKEN"); value != "" {
+		c.Lidarr.Token = value
+	}
+	if v, ok := os.LookupEnv("LIDARR_INSECURE_SKIP_VERIFY"); ok {
+		c.Lidarr.InsecureSkipVerify = isTruthy(v)
+	}
 }
 
 func (c *Config) loadFromEnvFile() {
@@ -207,6 +239,7 @@ func (c *Config) loadFromEnvFile() {
 	if f, ok := parseFloatEnv("PLEX_MAX_REQUESTS_PER_SECOND"); ok {
 		c.Plex.MaxRequestsPerSecond = f
 	}
+	c.loadLidarrFromEnv()
 }
 
 // loadPlexTLSFromEnv applies PLEX_INSECURE_SKIP_VERIFY and PLEX_VERIFY_TLS (VERIFY wins when truthy).
@@ -285,6 +318,15 @@ func parseLibrarySectionID(value string) (int, error) {
 
 // NormalizeMusicSocialBaseURL trims space and trailing slashes and validates as an absolute http(s) URL.
 func NormalizeMusicSocialBaseURL(raw string) (string, error) {
+	return normalizeHTTPBaseURL(raw)
+}
+
+// NormalizeLidarrBaseURL trims space and trailing slashes and validates LIDARR_URL (http or https with host).
+func NormalizeLidarrBaseURL(raw string) (string, error) {
+	return normalizeHTTPBaseURL(raw)
+}
+
+func normalizeHTTPBaseURL(raw string) (string, error) {
 	s := strings.TrimSpace(raw)
 	s = strings.TrimRight(s, "/")
 	if s == "" {
@@ -314,6 +356,20 @@ func (c *Config) validate() error {
 			return fmt.Errorf("invalid MUSIC_SOCIAL_URL: %w", err)
 		}
 		c.MusicSocial.BaseURL = base
+	}
+
+	lidarrURL := strings.TrimSpace(c.Lidarr.URL)
+	lidarrToken := strings.TrimSpace(c.Lidarr.Token)
+	if (lidarrURL != "" && lidarrToken == "") || (lidarrURL == "" && lidarrToken != "") {
+		return fmt.Errorf("LIDARR_URL and LIDARR_TOKEN must both be set to enable Lidarr integration, or both left unset")
+	}
+	if lidarrURL != "" {
+		norm, err := NormalizeLidarrBaseURL(lidarrURL)
+		if err != nil {
+			return fmt.Errorf("invalid LIDARR_URL: %w", err)
+		}
+		c.Lidarr.URL = norm
+		c.Lidarr.Token = lidarrToken
 	}
 
 	if c.Plex.URL == "" {
@@ -406,6 +462,12 @@ func (c *Config) applyOverrides(overrides map[string]string) {
 			if p, err := ParseMatchConfidencePercent(value); err == nil {
 				c.Plex.MatchConfidencePercent = p
 			}
+		case "LIDARR_URL":
+			c.Lidarr.URL = value
+		case "LIDARR_TOKEN":
+			c.Lidarr.Token = value
+		case "LIDARR_INSECURE_SKIP_VERIFY":
+			c.Lidarr.InsecureSkipVerify = isTruthy(value)
 		}
 	}
 	c.applyPlexTLSOverrides(overrides)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -358,3 +358,52 @@ func TestNormalizeMusicSocialBaseURL(t *testing.T) {
 		t.Error("expected error for non-http scheme")
 	}
 }
+
+func TestNormalizeLidarrBaseURL(t *testing.T) {
+	got, err := NormalizeLidarrBaseURL("http://10.0.0.1:8686/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "http://10.0.0.1:8686" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestLidarrValidationBothOrNeither(t *testing.T) {
+	cfg := &Config{
+		MusicSocial: MusicSocialConfig{BaseURL: "https://music.example.com", Username: "u"},
+		Plex: PlexConfig{
+			URL: "http://p:32400", Token: "t", LibrarySectionID: 1,
+		},
+	}
+	cfg.Lidarr.URL = "http://lidarr:8686"
+	cfg.Lidarr.Token = ""
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected error when only LIDARR URL set")
+	}
+
+	cfg.Lidarr.URL = ""
+	cfg.Lidarr.Token = "k"
+	if err := cfg.validate(); err == nil {
+		t.Fatal("expected error when only LIDARR token set")
+	}
+
+	cfg.Lidarr.URL = "http://lidarr:8686"
+	cfg.Lidarr.Token = "k"
+	if err := cfg.validate(); err != nil {
+		t.Fatalf("expected ok: %v", err)
+	}
+	if cfg.Lidarr.URL != "http://lidarr:8686" {
+		t.Errorf("url: %q", cfg.Lidarr.URL)
+	}
+}
+
+func TestLoadLidarrInsecureFromEnv(t *testing.T) {
+	t.Setenv("LIDARR_INSECURE_SKIP_VERIFY", "true")
+	cfg := &Config{}
+	cfg.initializeDefaults()
+	cfg.loadLidarrFromEnv()
+	if !cfg.Lidarr.InsecureSkipVerify {
+		t.Error("expected InsecureSkipVerify true")
+	}
+}

--- a/env.template
+++ b/env.template
@@ -67,6 +67,17 @@ PLEXIFY_MATCH_CONFIDENCE_PERCENT=80
 # PLEX_INSECURE_SKIP_VERIFY=false
 
 # =============================================================================
+# Lidarr (optional) — request adds for missing tracks that have a MusicBrainz release group
+# Set BOTH LIDARR_URL and LIDARR_TOKEN to enable. Omit both (or leave empty) to disable.
+# API key: Lidarr → Settings → Security.
+# Default for LIDARR_INSECURE_SKIP_VERIFY: verify certificates; set true for self-signed HTTPS.
+# =============================================================================
+
+# LIDARR_URL=http://your_lidarr_host:8686
+# LIDARR_TOKEN=
+# LIDARR_INSECURE_SKIP_VERIFY=true
+
+# =============================================================================
 # Output
 # Any non-empty value disables ANSI colors in playlist diff when stdout is a TTY
 # =============================================================================

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/grrywlsn/plexify/config"
 	"github.com/grrywlsn/plexify/internal/cliutil"
+	"github.com/grrywlsn/plexify/lidarr"
 	"github.com/grrywlsn/plexify/musicsocial"
 	"github.com/grrywlsn/plexify/plex"
 	"github.com/grrywlsn/plexify/track"
@@ -33,6 +34,7 @@ type Application struct {
 	config      *config.Config
 	musicSocial *musicsocial.Client
 	plexClient  *plex.Client
+	lidarr      *lidarr.Client
 }
 
 // NewApplication creates a new application instance. debug enables verbose Plex search logging.
@@ -48,10 +50,20 @@ func NewApplication(cfg *config.Config, debug bool) (*Application, error) {
 		slog.Info("Plex track matching: exact-matches-only (raw title/artist strategy; no title normalizations or full-library scan)")
 	}
 
+	var lclient *lidarr.Client
+	if cfg.LidarrEnabled() {
+		c, err := lidarr.NewClient(&cfg.Lidarr)
+		if err != nil {
+			return nil, fmt.Errorf("lidarr client: %w", err)
+		}
+		lclient = c
+	}
+
 	return &Application{
 		config:      cfg,
 		musicSocial: ms,
 		plexClient:  plexClient,
+		lidarr:      lclient,
 	}, nil
 }
 
@@ -222,7 +234,7 @@ func (app *Application) processPlaylist(ctx context.Context, meta PlaylistMeta, 
 		return fmt.Errorf("failed to match songs to Plex: %w", err)
 	}
 
-	app.displayMatchingResults(matchResults, songs, playlist, diffView)
+	app.displayMatchingResults(ctx, matchResults, songs, playlist, diffView)
 
 	return nil
 }
@@ -239,7 +251,7 @@ func (app *Application) displaySongs(songs []track.Track) {
 	fmt.Printf("Successfully fetched %d songs from source playlist\n", len(songs))
 }
 
-func (app *Application) displayMatchingResults(matchResults []plex.MatchResult, songs []track.Track, playlist *plex.PlexPlaylist, diffView plex.PlaylistDiffView) {
+func (app *Application) displayMatchingResults(ctx context.Context, matchResults []plex.MatchResult, songs []track.Track, playlist *plex.PlexPlaylist, diffView plex.PlaylistDiffView) {
 	fmt.Println("\n" + cliutil.RepeatChar("=", cliutil.SectionWidth))
 	fmt.Println("MATCHING RESULTS")
 	fmt.Println(cliutil.RepeatChar("=", cliutil.SectionWidth))
@@ -270,7 +282,7 @@ func (app *Application) displayMatchingResults(matchResults []plex.MatchResult, 
 	app.displaySummary(songs, titleMatches, noMatches, playlist, diffView)
 
 	if len(missingTracks) > 0 {
-		app.displayMissingTracksSummary(missingTracks)
+		app.displayMissingTracksSummary(ctx, missingTracks)
 	}
 }
 
@@ -300,7 +312,7 @@ func (app *Application) displaySummary(songs []track.Track, titleMatches, noMatc
 	}
 }
 
-func (app *Application) displayMissingTracksSummary(missingTracks []plex.MatchResult) {
+func (app *Application) displayMissingTracksSummary(ctx context.Context, missingTracks []plex.MatchResult) {
 	fmt.Println("\n" + cliutil.RepeatChar("=", cliutil.SectionWidth))
 	fmt.Println("MISSING TRACKS SUMMARY")
 	fmt.Println(cliutil.RepeatChar("=", cliutil.SectionWidth))
@@ -324,6 +336,58 @@ func (app *Application) displayMissingTracksSummary(missingTracks []plex.MatchRe
 		}
 		if i < len(missingTracks)-1 {
 			fmt.Println()
+		}
+	}
+
+	app.addMissingReleaseGroupsToLidarr(ctx, missingTracks)
+}
+
+func (app *Application) addMissingReleaseGroupsToLidarr(ctx context.Context, missing []plex.MatchResult) {
+	if app.lidarr == nil || !app.config.LidarrEnabled() {
+		return
+	}
+
+	seen := make(map[string]struct{})
+	var groupIDs []string
+	for _, m := range missing {
+		rg := strings.TrimSpace(m.SourceTrack.MusicBrainzReleaseGroupID)
+		if rg == "" {
+			continue
+		}
+		if _, ok := seen[rg]; ok {
+			continue
+		}
+		seen[rg] = struct{}{}
+		groupIDs = append(groupIDs, rg)
+	}
+	if len(groupIDs) == 0 {
+		return
+	}
+
+	if app.config.Plex.DryRun {
+		fmt.Println()
+		fmt.Println("Lidarr (dry-run): would request add for these MusicBrainz release group id(s):")
+		for _, id := range groupIDs {
+			fmt.Printf("  - %s\n", id)
+		}
+		return
+	}
+
+	fmt.Println()
+	fmt.Println(cliutil.RepeatChar("=", cliutil.SectionWidth))
+	fmt.Println("LIDARR: ADD MISSING RELEASE GROUPS")
+	fmt.Println(cliutil.RepeatChar("=", cliutil.SectionWidth))
+	for _, id := range groupIDs {
+		res, err := app.lidarr.AddReleaseGroupIfMissing(ctx, id)
+		if err != nil {
+			slog.Error("lidarr: add release group", "release_group", id, "err", err)
+			fmt.Printf("❌ Lidarr: could not add release group %s: %v\n", id, err)
+			continue
+		}
+		if res.AlreadyPresent {
+			fmt.Printf("ℹ️  Lidarr: release group %s already in library\n", id)
+		} else if res.Added {
+			fmt.Printf("✅ Lidarr: added release group %s (search for release started)\n", id)
 		}
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grrywlsn/plexify/config"
@@ -36,7 +37,7 @@ func TestDisplayMissingTracksSummary(t *testing.T) {
 		},
 	}
 
-	app.displayMissingTracksSummary(missingTracks)
+	app.displayMissingTracksSummary(context.Background(), missingTracks)
 }
 
 func TestFilterExcludedPlaylists_NoExclusions(t *testing.T) {

--- a/lidarr/client.go
+++ b/lidarr/client.go
@@ -1,0 +1,340 @@
+package lidarr
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/grrywlsn/plexify/config"
+)
+
+// Client calls the Lidarr HTTP API (v1).
+type Client struct {
+	base   string
+	apiKey string
+	http   *http.Client
+
+	addDefMu    sync.Mutex
+	addDefCache *addDefaults
+}
+
+type addDefaults struct {
+	rootFolderPath    string
+	qualityProfileID  int
+	metadataProfileID int
+}
+
+// NewClient builds a client for the given Lidarr config. Base URL and API key must be non-empty.
+func NewClient(cfg *config.LidarrConfig) (*Client, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("nil Lidarr config")
+	}
+	base := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	key := strings.TrimSpace(cfg.Token)
+	if base == "" || key == "" {
+		return nil, fmt.Errorf("Lidarr base URL and API token are required")
+	}
+	var tr http.RoundTripper
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		t := dt.Clone()
+		if cfg.InsecureSkipVerify {
+			t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		}
+		tr = t
+	} else if cfg.InsecureSkipVerify {
+		tr = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	} else {
+		tr = http.DefaultTransport
+	}
+	return &Client{
+		base:   base,
+		apiKey: key,
+		http: &http.Client{
+			Timeout:   60 * time.Second,
+			Transport: tr,
+		},
+	}, nil
+}
+
+// AddReleaseGroupResult is the outcome of trying to add a MusicBrainz release group to Lidarr.
+type AddReleaseGroupResult struct {
+	ReleaseGroupID string
+	AlreadyPresent bool
+	Added          bool
+}
+
+// AddReleaseGroupIfMissing looks up a MusicBrainz release group (Lidarr foreign album id), adds it
+// with search when not already in the Lidarr library, and is idempotent per Lidarr's album list.
+func (c *Client) AddReleaseGroupIfMissing(ctx context.Context, releaseGroupMBID string) (AddReleaseGroupResult, error) {
+	rid := strings.TrimSpace(releaseGroupMBID)
+	out := AddReleaseGroupResult{ReleaseGroupID: rid}
+	if rid == "" {
+		return out, fmt.Errorf("empty release group id")
+	}
+
+	present, err := c.albumInLibrary(ctx, rid)
+	if err != nil {
+		return out, err
+	}
+	if present {
+		out.AlreadyPresent = true
+		return out, nil
+	}
+
+	album, err := c.lookupFirstAlbum(ctx, rid)
+	if err != nil {
+		return out, err
+	}
+	if err := c.applyArtistAddDefaults(ctx, album); err != nil {
+		return out, err
+	}
+	if err := c.postAlbum(ctx, album); err != nil {
+		return out, err
+	}
+	out.Added = true
+	return out, nil
+}
+
+func (c *Client) albumInLibrary(ctx context.Context, foreignAlbumID string) (bool, error) {
+	u, err := url.Parse(c.base + "/api/v1/album")
+	if err != nil {
+		return false, err
+	}
+	q := u.Query()
+	q.Set("foreignAlbumId", foreignAlbumID)
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return false, err
+	}
+	c.setDefaultHeaders(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("list album by foreign id: %s: %s", resp.Status, strings.TrimSpace(string(b)))
+	}
+	var albums []json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&albums); err != nil {
+		return false, fmt.Errorf("decode album list: %w", err)
+	}
+	return len(albums) > 0, nil
+}
+
+func (c *Client) lookupFirstAlbum(ctx context.Context, releaseGroupMBID string) (map[string]interface{}, error) {
+	terms := []string{"lidarr:" + releaseGroupMBID, releaseGroupMBID}
+	for _, term := range terms {
+		album, err := c.albumLookup(ctx, term)
+		if err != nil {
+			return nil, err
+		}
+		if album != nil {
+			return album, nil
+		}
+	}
+	return nil, fmt.Errorf("Lidarr album/lookup returned no results for release group %s", releaseGroupMBID)
+}
+
+func (c *Client) albumLookup(ctx context.Context, term string) (map[string]interface{}, error) {
+	u, err := url.Parse(c.base + "/api/v1/album/lookup")
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("term", term)
+	u.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setDefaultHeaders(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("album/lookup: %s: %s", resp.Status, strings.TrimSpace(string(b)))
+	}
+	var albums []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&albums); err != nil {
+		return nil, fmt.Errorf("decode lookup: %w", err)
+	}
+	if len(albums) == 0 {
+		return nil, nil
+	}
+	return albums[0], nil
+}
+
+// applyArtistAddDefaults sets artist.qualityProfileId, artist.metadataProfileId, and artist.rootFolderPath
+// when the lookup payload has 0/empty values — Lidarr requires these for a new artist. Uses the first
+// root folder from GET /api/v1/rootfolder (and its default* profile ids when set), else first profile
+// from GET /api/v1/qualityprofile and GET /api/v1/metadataprofile. Results are cached per Client.
+func (c *Client) applyArtistAddDefaults(ctx context.Context, album map[string]interface{}) error {
+	def, err := c.getAddDefaults(ctx)
+	if err != nil {
+		return err
+	}
+	art, ok := album["artist"].(map[string]interface{})
+	if !ok || art == nil {
+		art = make(map[string]interface{})
+		album["artist"] = art
+	}
+	if !positiveIntFromJSON(art["qualityProfileId"]) {
+		art["qualityProfileId"] = def.qualityProfileID
+	}
+	if !positiveIntFromJSON(art["metadataProfileId"]) {
+		art["metadataProfileId"] = def.metadataProfileID
+	}
+	if s, _ := art["rootFolderPath"].(string); strings.TrimSpace(s) == "" {
+		art["rootFolderPath"] = def.rootFolderPath
+	}
+	return nil
+}
+
+func (c *Client) getAddDefaults(ctx context.Context) (*addDefaults, error) {
+	c.addDefMu.Lock()
+	defer c.addDefMu.Unlock()
+	if c.addDefCache != nil {
+		return c.addDefCache, nil
+	}
+	d, err := c.fetchAddDefaults(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.addDefCache = d
+	return c.addDefCache, nil
+}
+
+func (c *Client) fetchAddDefaults(ctx context.Context) (*addDefaults, error) {
+	roots, err := c.getJSONSlice(ctx, "/api/v1/rootfolder")
+	if err != nil {
+		return nil, fmt.Errorf("root folder: %w", err)
+	}
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("Lidarr has no root folders configured (Settings → Media Management → Root Folders)")
+	}
+	root := roots[0]
+	path, _ := root["path"].(string)
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("first Lidarr root folder has no path")
+	}
+	out := &addDefaults{rootFolderPath: path}
+
+	qp := intFromInterface(root["defaultQualityProfileId"])
+	mp := intFromInterface(root["defaultMetadataProfileId"])
+	if qp <= 0 {
+		profiles, err := c.getJSONSlice(ctx, "/api/v1/qualityprofile")
+		if err != nil {
+			return nil, fmt.Errorf("quality profile: %w", err)
+		}
+		if len(profiles) == 0 {
+			return nil, fmt.Errorf("Lidarr has no quality profiles")
+		}
+		qp = intFromInterface(profiles[0]["id"])
+	}
+	if mp <= 0 {
+		profiles, err := c.getJSONSlice(ctx, "/api/v1/metadataprofile")
+		if err != nil {
+			return nil, fmt.Errorf("metadata profile: %w", err)
+		}
+		if len(profiles) == 0 {
+			return nil, fmt.Errorf("Lidarr has no metadata profiles")
+		}
+		mp = intFromInterface(profiles[0]["id"])
+	}
+	if qp <= 0 || mp <= 0 {
+		return nil, fmt.Errorf("could not resolve default quality (%d) or metadata (%d) profile id", qp, mp)
+	}
+	out.qualityProfileID = qp
+	out.metadataProfileID = mp
+	return out, nil
+}
+
+func (c *Client) getJSONSlice(ctx context.Context, path string) ([]map[string]interface{}, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setDefaultHeaders(req)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("%s: %s", resp.Status, strings.TrimSpace(string(b)))
+	}
+	var out []map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func intFromInterface(v interface{}) int {
+	switch x := v.(type) {
+	case float64:
+		return int(x)
+	case int:
+		return x
+	case int64:
+		return int(x)
+	case json.Number:
+		i, _ := x.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}
+
+func positiveIntFromJSON(v interface{}) bool {
+	return intFromInterface(v) > 0
+}
+
+func (c *Client) postAlbum(ctx context.Context, album map[string]interface{}) error {
+	album["monitored"] = true
+	album["addOptions"] = map[string]interface{}{
+		"searchForNewAlbum": true,
+	}
+	body, err := json.Marshal(album)
+	if err != nil {
+		return err
+	}
+	u := c.base + "/api/v1/album"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	c.setDefaultHeaders(req)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("add album: %s: %s", resp.Status, strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
+func (c *Client) setDefaultHeaders(req *http.Request) {
+	req.Header.Set("X-Api-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+}

--- a/lidarr/client_test.go
+++ b/lidarr/client_test.go
@@ -1,0 +1,213 @@
+package lidarr
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grrywlsn/plexify/config"
+)
+
+func TestNewClientEmpty(t *testing.T) {
+	_, err := NewClient(&config.LidarrConfig{URL: "http://127.0.0.1:1", Token: ""})
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+	_, err = NewClient(&config.LidarrConfig{URL: "", Token: "k"})
+	if err == nil {
+		t.Fatal("expected error for empty URL")
+	}
+}
+
+func TestAddReleaseGroupIfMissing_Adds(t *testing.T) {
+	mbid := "46336fb9-d9d6-4322-b044-d7f7ded5e5e2"
+	lookup := []map[string]interface{}{
+		{
+			"title":          "Test Album",
+			"foreignAlbumId": mbid,
+			"artist":         map[string]interface{}{"foreignArtistId": "a1"},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album" && r.URL.Query().Get("foreignAlbumId") == mbid:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/rootfolder":
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{{
+				"path":                     "/music",
+				"defaultQualityProfileId":  1,
+				"defaultMetadataProfileId": 2,
+			}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album/lookup":
+			if r.URL.Query().Get("term") == "lidarr:"+mbid {
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(lookup)
+				return
+			}
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/album":
+			var got map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&got)
+			ao, _ := got["addOptions"].(map[string]interface{})
+			if ao == nil || ao["searchForNewAlbum"] != true {
+				t.Error("expected addOptions.searchForNewAlbum true")
+			}
+			if got["monitored"] != true {
+				t.Error("expected monitored true")
+			}
+			art, _ := got["artist"].(map[string]interface{})
+			if art == nil {
+				t.Fatal("expected artist in POST body")
+			}
+			if int(art["qualityProfileId"].(float64)) != 1 {
+				t.Errorf("expected qualityProfileId 1, got %v", art["qualityProfileId"])
+			}
+			if int(art["metadataProfileId"].(float64)) != 2 {
+				t.Errorf("expected metadataProfileId 2, got %v", art["metadataProfileId"])
+			}
+			if art["rootFolderPath"] != "/music" {
+				t.Errorf("rootFolderPath: %v", art["rootFolderPath"])
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(&config.LidarrConfig{URL: srv.URL, Token: "key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := c.AddReleaseGroupIfMissing(context.Background(), mbid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Added || res.AlreadyPresent {
+		t.Fatalf("got %#v", res)
+	}
+}
+
+func TestAddReleaseGroupIfMissing_SkipWhenPresent(t *testing.T) {
+	mbid := "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/api/v1/album" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[{"id":1}]`))
+			return
+		}
+		t.Fatalf("unexpected %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(&config.LidarrConfig{URL: srv.URL, Token: "key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := c.AddReleaseGroupIfMissing(context.Background(), mbid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.AlreadyPresent || res.Added {
+		t.Fatalf("got %#v", res)
+	}
+}
+
+func TestFetchAddDefaults_UsesProfileListsWhenRootHasNoDefaults(t *testing.T) {
+	mbid := "22222222-2222-2222-2222-222222222222"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album" && r.URL.Query().Get("foreignAlbumId") == mbid:
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/rootfolder":
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{{"path": "/tmp/music"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/qualityprofile":
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{{"id": 7}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/metadataprofile":
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{{"id": 8}})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album/lookup" && r.URL.Query().Get("term") == "lidarr:"+mbid:
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"foreignAlbumId": mbid, "title": "Y", "artist": map[string]interface{}{}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album/lookup":
+			_, _ = w.Write([]byte("[]"))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/album":
+			var got map[string]interface{}
+			_ = json.NewDecoder(r.Body).Decode(&got)
+			art, _ := got["artist"].(map[string]interface{})
+			if int(art["qualityProfileId"].(float64)) != 7 || int(art["metadataProfileId"].(float64)) != 8 {
+				t.Errorf("artist profiles: %v", art)
+			}
+			if art["rootFolderPath"] != "/tmp/music" {
+				t.Errorf("rootFolderPath: %v", art["rootFolderPath"])
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(&config.LidarrConfig{URL: srv.URL, Token: "k"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.AddReleaseGroupIfMissing(context.Background(), mbid)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddReleaseGroupIfMissing_FallbackTerm(t *testing.T) {
+	mbid := "11111111-1111-1111-1111-111111111111"
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/album" {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		if r.URL.Path == "/api/v1/rootfolder" {
+			_ = json.NewEncoder(w).Encode([]map[string]interface{}{{
+				"path":                     "/m",
+				"defaultQualityProfileId":  3,
+				"defaultMetadataProfileId": 4,
+			}})
+			return
+		}
+		if r.URL.Path == "/api/v1/album/lookup" {
+			term := r.URL.Query().Get("term")
+			if term == "lidarr:"+mbid {
+				_, _ = w.Write([]byte("[]"))
+				return
+			}
+			if term == mbid {
+				calls++
+				_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+					{"foreignAlbumId": mbid, "title": "X"},
+				})
+				return
+			}
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/album" {
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		t.Fatalf("unexpected %s", r.URL.String())
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(&config.LidarrConfig{URL: srv.URL, Token: "k"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.AddReleaseGroupIfMissing(context.Background(), mbid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected fallback term used once, got %d", calls)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -33,6 +33,12 @@ func parseFlags() map[string]string {
 	flag.StringVar(&plexLibrarySectionID, "PLEX_LIBRARY_SECTION_ID", "", "Plex library section ID (overrides env var)")
 	flag.StringVar(&plexServerID, "PLEX_SERVER_ID", "", "Plex server ID (overrides env var)")
 
+	var lidarrURL, lidarrToken string
+	flag.StringVar(&lidarrURL, "LIDARR_URL", "", "Lidarr base URL for auto-adding missing MB release groups (overrides env; requires LIDARR_TOKEN)")
+	flag.StringVar(&lidarrToken, "LIDARR_TOKEN", "", "Lidarr API key (overrides env; requires LIDARR_URL)")
+	var lidarrInsecureSkipVerify bool
+	flag.BoolVar(&lidarrInsecureSkipVerify, "lidarr-insecure-skip-verify", false, "Skip TLS verify for Lidarr HTTPS (same as LIDARR_INSECURE_SKIP_VERIFY=true)")
+
 	var dryRun bool
 	flag.BoolVar(&dryRun, "dry-run", false, "Match and show diff only; do not modify Plex playlists (same as PLEXIFY_DRY_RUN=true)")
 
@@ -89,6 +95,15 @@ func parseFlags() map[string]string {
 	}
 	if plexServerID != "" {
 		overrides["PLEX_SERVER_ID"] = plexServerID
+	}
+	if lidarrURL != "" {
+		overrides["LIDARR_URL"] = lidarrURL
+	}
+	if lidarrToken != "" {
+		overrides["LIDARR_TOKEN"] = lidarrToken
+	}
+	if lidarrInsecureSkipVerify {
+		overrides["LIDARR_INSECURE_SKIP_VERIFY"] = "true"
 	}
 	if dryRun {
 		overrides["PLEXIFY_DRY_RUN"] = "true"


### PR DESCRIPTION
## Summary

Optional Lidarr integration: when `LIDARR_URL` and `LIDARR_TOKEN` are both set, Plexify requests Lidarr to add **MusicBrainz release groups** for missing tracks that expose `musicbrainz.release_group_gid` (deduplicated per run). Respects `PLEXIFY_DRY_RUN` (prints what would be sent; no Lidarr HTTP calls).

## Implementation

- New `lidarr` package: lookup via `/api/v1/album/lookup`, idempotent check via `/api/v1/album?foreignAlbumId=`, then `POST /api/v1/album` with `addOptions.searchForNewAlbum`.
- Fills `artist.qualityProfileId`, `artist.metadataProfileId`, and `artist.rootFolderPath` from the Lidarr instance (first root folder; default profile ids on that folder when set, otherwise first entries from quality/metadata profile lists). Caches defaults per client.
- Config: `LIDARR_INSECURE_SKIP_VERIFY`, validation (URL and token both or neither), CLI flags.
- Docs: README, `env.template`.

## Testing

`go test ./...` (including `httptest` coverage for the Lidarr client).

Made with [Cursor](https://cursor.com)