### PR TITLE
fix(plex): match en-dash titles against Plex hyphen metadata

### DIFF
--- a/plex/client_test.go
+++ b/plex/client_test.go
@@ -2731,7 +2731,8 @@ func TestPunctuationMatching(t *testing.T) {
 			{"Don't Stop", "Don't Stop", "Contraction apostrophe"},
 			{"O'Connor", "O'Connor", "Name with apostrophe"},
 			{"Mary-Jane", "Mary-Jane", "Name with hyphen"},
-			{"Mary‐Jane", "Mary-Jane", "Name with en dash"},
+			{"Mary‐Jane", "Mary-Jane", "Name with Unicode hyphen (U+2010)"},
+			{"9\u20135", "9-5", "En dash (U+2013) in track title vs ASCII hyphen"},
 			{"Chloe x Halle", "Chloe x Halle", "Regular 'x'"},
 			{"Chloe × Halle", "Chloe x Halle", "Multiplication symbol to 'x'"},
 		}

--- a/plex/normalize.go
+++ b/plex/normalize.go
@@ -291,10 +291,11 @@ func (c *Client) normalizeTitle(s string) string {
 
 // normalizePunctuation normalizes various punctuation marks to standard forms
 func (c *Client) normalizePunctuation(s string) string {
-	// Normalize various types of dashes to standard hyphens
-	s = strings.ReplaceAll(s, "\u2010", "-") // En dash to hyphen
-	s = strings.ReplaceAll(s, "\u2014", "-") // Em dash to hyphen
-	s = strings.ReplaceAll(s, "\u2015", "-") // Horizontal bar to hyphen
+	// Normalize various types of dashes to standard ASCII hyphen-minus
+	s = strings.ReplaceAll(s, "\u2010", "-") // Unicode hyphen
+	s = strings.ReplaceAll(s, "\u2013", "-") // En dash
+	s = strings.ReplaceAll(s, "\u2014", "-") // Em dash
+	s = strings.ReplaceAll(s, "\u2015", "-") // Horizontal bar
 
 	// Normalize multiplication symbol to 'x' for artist names like "Chloe × Halle"
 	s = strings.ReplaceAll(s, "\u00D7", "x") // Multiplication symbol to 'x'

--- a/plex/search.go
+++ b/plex/search.go
@@ -133,6 +133,16 @@ func (c *Client) indexedTrackSearchStrategies() []trackSearchStrategy {
 		{"exact title/artist", func(ctx context.Context, phase searchPhase, title, artist, sourceAlbum string) (*PlexTrack, error) {
 			return c.trySearchVariationsPhase(ctx, title, artist, sourceAlbum, phase)
 		}},
+		// Indexed Plex /search is literal: en dash vs hyphen in the query string changes hits. Re-run
+		// with the same normalizations as FindBestMatch (e.g. U+2013 → -) so "9–5" finds "9-5".
+		{"punctuation normalized", func(ctx context.Context, phase searchPhase, title, artist, sourceAlbum string) (*PlexTrack, error) {
+			pt := c.normalizePunctuation(title)
+			pa := c.normalizePunctuation(artist)
+			if pt == title && pa == artist {
+				return nil, nil
+			}
+			return c.trySearchVariationsPhase(ctx, pt, pa, sourceAlbum, phase)
+		}},
 		{"single quote variations", func(ctx context.Context, phase searchPhase, title, artist, sourceAlbum string) (*PlexTrack, error) {
 			if strings.Contains(title, "'") || strings.Contains(artist, "'") ||
 				strings.Contains(title, "'") || strings.Contains(artist, "'") {

--- a/plex/search_test.go
+++ b/plex/search_test.go
@@ -1,8 +1,14 @@
 package plex
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/grrywlsn/plexify/config"
 	"github.com/grrywlsn/plexify/track"
 )
 
@@ -84,6 +90,23 @@ func TestFindBestMatchWithNormalizedPunctuation_variousArtistsOriginalTitle(t *t
 	}
 }
 
+// Source catalogs (e.g. music-social / MusicBrainz) often use U+2013 EN DASH in titles; Plex
+// and local files often store the ASCII hyphen-minus. Both matchers must treat them as equivalent.
+func TestFindBestMatch_enDashInTitleMatchesPlexHyphen(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	srcTitle := "9\u20135" // 9–5
+	plexTracks := []PlexTrack{{
+		ID: "1", Title: "9-5", Artist: "Biig Piig", Album: "11:11",
+	}}
+	if got := c.FindBestMatch(plexTracks, srcTitle, "Biig Piig", "11:11"); got == nil || got.ID != "1" {
+		t.Fatalf("FindBestMatch: expected en-dash source title to match Plex hyphen, got %v", got)
+	}
+	if got := c.FindBestMatchWithNormalizedPunctuation(plexTracks, srcTitle, "Biig Piig", "11:11"); got == nil || got.ID != "1" {
+		t.Fatalf("FindBestMatchWithNormalizedPunctuation: expected match, got %v", got)
+	}
+}
+
 func TestCalculateConfidence_variousArtistsOriginalTitle(t *testing.T) {
 	t.Parallel()
 	c := &Client{}
@@ -104,5 +127,66 @@ func TestIndexedTrackSearchStrategies_order(t *testing.T) {
 	}
 	if strategies[0].name != "exact title/artist" {
 		t.Fatalf("first strategy should be exact title/artist, got %q", strategies[0].name)
+	}
+	if strategies[1].name != "punctuation normalized" {
+		t.Fatalf("second strategy should be punctuation normalized, got %q", strategies[1].name)
+	}
+}
+
+// When the source title uses a Unicode en dash, Plex /search may return no rows for that query, even
+// though the file is stored as "9-5". A second strategy must repeat the search with
+// normalizePunctuation (ASCII hyphen) in the request.
+func TestSearchTrack_punctuationNormalizedQueryFindsPlexHyphenTitle(t *testing.T) {
+	t.Parallel()
+	const sectionID = 2
+	srcTitle := "9\u20135" // 9–5
+	srcArtist := "Biig Piig"
+	srcAlbum := "11:11"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fmt.Sprintf("/library/sections/%d/search", sectionID) {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		q := r.URL.Query().Get("query")
+		if strings.Contains(q, "\u2013") {
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><MediaContainer size="0"></MediaContainer>`))
+			return
+		}
+		if q == "Biig Piig" {
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><MediaContainer size="0"></MediaContainer>`))
+			return
+		}
+		if q == "9-5" || q == "9-5 Biig Piig" {
+			_, _ = fmt.Fprintf(w, `<?xml version="1.0"?><MediaContainer size="1">`+
+				`<Track ratingKey="1" title="9-5" grandparentTitle="Biig Piig" parentTitle="11:11"/>`+
+				`</MediaContainer>`)
+			return
+		}
+		_, _ = w.Write([]byte(`<?xml version="1.0"?><MediaContainer size="0"></MediaContainer>`))
+	}))
+	defer ts.Close()
+
+	cfg := &config.Config{
+		Plex: config.PlexConfig{
+			URL:                    ts.URL,
+			Token:                  "tok",
+			LibrarySectionID:       sectionID,
+			MatchConfidencePercent: config.DefaultMatchConfidencePercent,
+		},
+	}
+	c := NewClient(cfg)
+	// Reproduce: indexed search only; en-dash must not force relying on a generous artist result set.
+	c.SetSkipFullLibrarySearch(true)
+
+	got, kind, err := c.SearchTrack(context.Background(), track.Track{Name: srcTitle, Artist: srcArtist, Album: srcAlbum})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.ID != "1" {
+		t.Fatalf("expected match via punctuation-normalized search query, got %v (kind %s)", got, kind)
+	}
+	if kind != MatchTypeTitleArtist {
+		t.Errorf("expected MatchTypeTitleArtist, got %s", kind)
 	}
 }


### PR DESCRIPTION
## Summary

Source playlists (e.g. music-social / MusicBrainz) sometimes use **U+2013 en dash** in titles (e.g. `9–5`) while Plex stores **ASCII hyphen** (`9-5`). Matching failed for two reasons:

1. **Scoring / normalization:** `normalizePunctuation` did not map en dash to `-` (only other dash code points). `FindBestMatch` could not treat the strings as equivalent when results were present.
2. **Plex /search:** The indexed search uses the raw title in the `query` parameter. Queries with an en dash often return **no rows**, so `FindBestMatch` never ran on the real track.

## Changes

- **`normalize.go`:** Add `\u2013` → `-`, clarify comments for dash code points.
- **`search.go`:** Add a **punctuation normalized** strategy (second after exact) that runs the same search pipeline with `normalizePunctuation` on title and artist so the second query uses `9-5`.
- **Tests:** `FindBestMatch` / `FindBestMatchWithNormalizedPunctuation`, `normalizePunctuation` table case, `TestSearchTrack_punctuationNormalizedQueryFindsPlexHyphenTitle` (httptest: en-dash queries empty, ASCII query returns the track).

## Patch

Download the single-commit patch from the PR checks page or run:

```bash
git fetch origin fix/en-dash-plex-track-matching
git format-patch -1 origin/main..origin/fix/en-dash-plex-track-matching -o /tmp
```


Made with [Cursor](https://cursor.com)