### PR TITLE
Plex: match legacy artist names using Sort Artist (titleSort)

### DIFF
--- a/musicsocial/client.go
+++ b/musicsocial/client.go
@@ -94,10 +94,16 @@ type appleMusicDTO struct {
 	AlbumID string `json:"album_id"`
 }
 
+type mbArtistCreditDTO struct {
+	ArtistGID string `json:"artist_gid"`
+	Name      string `json:"name"`
+}
+
 type mbTrackDTO struct {
-	TrackGID        string   `json:"track_gid"`
-	ReleaseGroupGID string   `json:"release_group_gid,omitempty"`
-	ISRCs           []string `json:"isrcs,omitempty"`
+	TrackGID        string              `json:"track_gid"`
+	ReleaseGroupGID string              `json:"release_group_gid,omitempty"`
+	ISRCs           []string            `json:"isrcs,omitempty"`
+	ArtistCredits   []mbArtistCreditDTO `json:"artist_credits,omitempty"`
 }
 
 // ListUserPlaylists returns public playlists for username.
@@ -165,6 +171,11 @@ func (c *Client) GetPlaylist(playlistID string) (*Playlist, error) {
 			tr.MusicBrainzReleaseGroupID = tj.MB.ReleaseGroupGID
 			if len(tj.MB.ISRCs) > 0 {
 				tr.ISRC = tj.MB.ISRCs[0]
+			}
+			for _, ac := range tj.MB.ArtistCredits {
+				if n := strings.TrimSpace(ac.Name); n != "" {
+					tr.MusicBrainzArtistCredits = append(tr.MusicBrainzArtistCredits, n)
+				}
 			}
 		}
 		if tj.Spotify != nil {

--- a/musicsocial/client_test.go
+++ b/musicsocial/client_test.go
@@ -71,6 +71,48 @@ func TestClient_GetPlaylist(t *testing.T) {
 	}
 }
 
+func TestClient_GetPlaylist_musicbrainzArtistCredits(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/playlist/plmb.json" {
+			http.NotFound(w, r)
+			return
+		}
+		doc := map[string]any{
+			"id": "plmb", "title": "MB", "owner": "alice", "track_count": 1,
+			"updated_at": "2025-01-01T00:00:00Z",
+			"tracks": []map[string]any{
+				{
+					"position": 1, "title": "Dirty Talk", "artist": "Diana Gordon", "album": "Dirty Talk",
+					"musicbrainz": map[string]any{
+						"track_gid": "tg",
+						"artist_credits": []map[string]any{
+							{"artist_gid": "aec279b2-b9cc-488c-b892-f2271605fa11", "name": "Wynter Gordon"},
+						},
+					},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(doc)
+	}))
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pl, err := c.GetPlaylist("plmb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pl.Tracks) != 1 {
+		t.Fatalf("want 1 track, got %d", len(pl.Tracks))
+	}
+	tr := pl.Tracks[0]
+	if len(tr.MusicBrainzArtistCredits) != 1 || tr.MusicBrainzArtistCredits[0] != "Wynter Gordon" {
+		t.Fatalf("credits: %+v", tr.MusicBrainzArtistCredits)
+	}
+}
+
 func TestClient_GetPlaylist_streamingAlbums(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/playlist/pl2.json" {

--- a/plex/artist_sort.go
+++ b/plex/artist_sort.go
@@ -1,0 +1,234 @@
+package plex
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// Threshold for including a track's grandparent artist in sort-title enrichment during full-library scan.
+const libraryArtistSortEnrichTitleThreshold = 0.85
+
+// Max distinct artist rating keys to fetch when enriching full-library results (after title filter).
+const libraryArtistSortEnrichMaxKeys = 500
+
+type plexArtistMediaContainer struct {
+	XMLName xml.Name       `xml:"MediaContainer"`
+	Artists []plexArtistEl `xml:"Artist"`
+	Dirs    []plexArtistEl `xml:"Directory"` // some Plex builds use Directory for artists
+}
+
+type plexArtistEl struct {
+	Title     string `xml:"title,attr"`
+	TitleSort string `xml:"titleSort,attr"`
+	Type      string `xml:"type,attr"`
+}
+
+func (c *Client) ensureArtistSortCache() {
+	c.artistSortMu.Lock()
+	defer c.artistSortMu.Unlock()
+	if c.artistSortCache == nil {
+		c.artistSortCache = make(map[string]string)
+	}
+}
+
+// getArtistTitleSort fetches Plex Artist titleSort for an artist rating key (Sort Artist in the UI).
+func (c *Client) getArtistTitleSort(ctx context.Context, artistRatingKey string) (string, error) {
+	key := strings.TrimSpace(artistRatingKey)
+	if key == "" {
+		return "", nil
+	}
+	reqURL := fmt.Sprintf("%s/library/metadata/%s", strings.TrimSuffix(c.baseURL, "/"), url.PathEscape(key))
+	params := url.Values{}
+	params.Add("X-Plex-Token", c.token)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL+"?"+params.Encode(), nil)
+	if err != nil {
+		return "", fmt.Errorf("artist metadata request: %w", err)
+	}
+	req.Header.Set("Accept", "application/xml")
+
+	resp, err := c.httpDo(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return "", newPlexHTTPError(resp.StatusCode, "artist metadata", b)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	var mc plexArtistMediaContainer
+	if err := xml.Unmarshal(raw, &mc); err != nil {
+		return "", fmt.Errorf("decode artist metadata: %w", err)
+	}
+	el := firstArtistElement(mc)
+	if el == nil {
+		return "", nil
+	}
+	ts := strings.TrimSpace(el.TitleSort)
+	if ts == "" {
+		ts = strings.TrimSpace(el.Title)
+	}
+	return ts, nil
+}
+
+func firstArtistElement(mc plexArtistMediaContainer) *plexArtistEl {
+	for i := range mc.Artists {
+		return &mc.Artists[i]
+	}
+	for i := range mc.Dirs {
+		if strings.EqualFold(strings.TrimSpace(mc.Dirs[i].Type), "artist") {
+			return &mc.Dirs[i]
+		}
+	}
+	if len(mc.Dirs) > 0 {
+		return &mc.Dirs[0]
+	}
+	return nil
+}
+
+// getArtistTitleSortCached returns titleSort for key, using an in-memory cache.
+func (c *Client) getArtistTitleSortCached(ctx context.Context, artistRatingKey string) (string, error) {
+	key := strings.TrimSpace(artistRatingKey)
+	if key == "" {
+		return "", nil
+	}
+	c.ensureArtistSortCache()
+	c.artistSortMu.Lock()
+	if ts, ok := c.artistSortCache[key]; ok {
+		c.artistSortMu.Unlock()
+		return ts, nil
+	}
+	c.artistSortMu.Unlock()
+
+	ts, err := c.getArtistTitleSort(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	c.artistSortMu.Lock()
+	c.artistSortCache[key] = ts
+	c.artistSortMu.Unlock()
+	return ts, nil
+}
+
+// enrichGrandparentSortTitles fills GrandparentTitleSort on tracks. If keysFilter is nil, every distinct
+// GrandparentRatingKey in tracks is fetched. If non-nil, only keys present in the map are fetched and applied.
+func (c *Client) enrichGrandparentSortTitles(ctx context.Context, tracks []PlexTrack, keysFilter map[string]struct{}) error {
+	wantKeys := keysFilter
+	if wantKeys == nil {
+		wantKeys = make(map[string]struct{})
+		for _, tr := range tracks {
+			if k := strings.TrimSpace(tr.GrandparentRatingKey); k != "" {
+				wantKeys[k] = struct{}{}
+			}
+		}
+	}
+	for k := range wantKeys {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if _, err := c.getArtistTitleSortCached(ctx, k); err != nil {
+			slog.WarnContext(ctx, "plex artist sort fetch failed; continuing without titleSort for key",
+				"key", k, "err", err)
+		}
+	}
+	c.ensureArtistSortCache()
+	c.artistSortMu.Lock()
+	cache := c.artistSortCache
+	c.artistSortMu.Unlock()
+
+	for i := range tracks {
+		k := strings.TrimSpace(tracks[i].GrandparentRatingKey)
+		if k == "" {
+			continue
+		}
+		if keysFilter != nil {
+			if _, ok := keysFilter[k]; !ok {
+				continue
+			}
+		}
+		if ts, ok := cache[k]; ok {
+			tracks[i].GrandparentTitleSort = ts
+		}
+	}
+	return nil
+}
+
+type keyScore struct {
+	key   string
+	score float64
+}
+
+// grandparentKeysForLibrarySortEnrichment returns artist rating keys to enrich after Pass 1 fails on /all:
+// keys whose track has title similarity to queryTitle above libraryArtistSortEnrichTitleThreshold,
+// capped at libraryArtistSortEnrichMaxKeys by best title score.
+func (c *Client) grandparentKeysForLibrarySortEnrichment(tracks []PlexTrack, queryTitle string) map[string]struct{} {
+	tl := strings.ToLower(strings.TrimSpace(queryTitle))
+	best := make(map[string]float64)
+	for _, tr := range tracks {
+		k := strings.TrimSpace(tr.GrandparentRatingKey)
+		if k == "" {
+			continue
+		}
+		ts := c.calculateStringSimilarity(tl, strings.ToLower(strings.TrimSpace(tr.Title)))
+		if ts < libraryArtistSortEnrichTitleThreshold {
+			continue
+		}
+		if prev, ok := best[k]; !ok || ts > prev {
+			best[k] = ts
+		}
+	}
+	if len(best) == 0 {
+		return nil
+	}
+	var pairs []keyScore
+	for k, s := range best {
+		pairs = append(pairs, keyScore{key: k, score: s})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].score != pairs[j].score {
+			return pairs[i].score > pairs[j].score
+		}
+		return pairs[i].key < pairs[j].key
+	})
+	out := make(map[string]struct{})
+	for i := 0; i < len(pairs) && i < libraryArtistSortEnrichMaxKeys; i++ {
+		out[pairs[i].key] = struct{}{}
+	}
+	return out
+}
+
+// findBestMatchWithOptionalArtistSortRetry runs FindBestMatch without GrandparentTitleSort; if it returns nil,
+// enriches artist sort titles and runs FindBestMatch once more. libraryScan triggers bounded key selection for /all.
+func (c *Client) findBestMatchWithOptionalArtistSortRetry(ctx context.Context, tracks []PlexTrack, title, artist, sourceAlbum string, libraryScan bool) *PlexTrack {
+	if len(tracks) == 0 {
+		return nil
+	}
+	if first := c.FindBestMatch(tracks, title, artist, sourceAlbum); first != nil {
+		return first
+	}
+	var keysFilter map[string]struct{}
+	if libraryScan {
+		keysFilter = c.grandparentKeysForLibrarySortEnrichment(tracks, title)
+		if len(keysFilter) == 0 {
+			return nil
+		}
+	}
+	if err := c.enrichGrandparentSortTitles(ctx, tracks, keysFilter); err != nil {
+		slog.WarnContext(ctx, "enrich grandparent sort titles failed", "err", err)
+		return nil
+	}
+	return c.FindBestMatch(tracks, title, artist, sourceAlbum)
+}

--- a/plex/artist_sort_test.go
+++ b/plex/artist_sort_test.go
@@ -1,0 +1,168 @@
+package plex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grrywlsn/plexify/config"
+	"github.com/grrywlsn/plexify/track"
+)
+
+func TestFindBestMatch_grandparentTitleSortRename(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	defaultPct := config.DefaultMatchConfidencePercent
+	c.matchConfidencePercent = &defaultPct
+	tracks := []PlexTrack{{
+		ID:                   "1",
+		Title:                "Dirty Talk",
+		Artist:               "Diana Gordon",
+		GrandparentTitleSort: "Wynter Gordon",
+		Album:                "Dirty Talk",
+	}}
+	got := c.FindBestMatch(tracks, "Dirty Talk", "Wynter Gordon", "Dirty Talk")
+	if got == nil || got.ID != "1" {
+		t.Fatalf("expected match via GrandparentTitleSort, got %v", got)
+	}
+}
+
+func TestPlexTrack_exactTitleAndArtistMatch_grandparentTitleSort(t *testing.T) {
+	t.Parallel()
+	tr := PlexTrack{Title: "Dirty Talk", Artist: "Diana Gordon", GrandparentTitleSort: "Wynter Gordon"}
+	if !tr.exactTitleAndArtistMatch("dirty talk", "wynter gordon") {
+		t.Fatal("expected exact match on GrandparentTitleSort")
+	}
+	if !tr.exactTitleAndArtistMatch("dirty talk", "diana gordon") {
+		t.Fatal("expected exact match on grandparentTitle (display artist)")
+	}
+}
+
+func TestFindBestMatch_twoCandidates_sortDoesNotStealOriginalTitle(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	defaultPct := config.DefaultMatchConfidencePercent
+	c.matchConfidencePercent = &defaultPct
+	tracks := []PlexTrack{
+		{ID: "a", Title: "Song", Artist: "Various Artists", OriginalTitle: "Other", Album: "Comp"},
+		{ID: "b", Title: "Song", Artist: "Various Artists", OriginalTitle: "Madonna", Album: "Comp", GrandparentTitleSort: "Madonna Sort"},
+	}
+	got := c.FindBestMatch(tracks, "Song", "Madonna", "Comp")
+	if got == nil || got.ID != "b" {
+		t.Fatalf("wanted originalTitle row b, got %v", got)
+	}
+}
+
+func TestCalculateConfidence_grandparentTitleSort(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	song := track.Track{Name: "Dirty Talk", Artist: "Wynter Gordon", Album: "Dirty Talk"}
+	withSort := &PlexTrack{Title: "Dirty Talk", Artist: "Diana Gordon", GrandparentTitleSort: "Wynter Gordon", Album: "Dirty Talk"}
+	noSort := &PlexTrack{Title: "Dirty Talk", Artist: "Diana Gordon", Album: "Dirty Talk"}
+	confWith := c.calculateConfidence(song, withSort, MatchTypeTitleArtist)
+	confNo := c.calculateConfidence(song, noSort, MatchTypeTitleArtist)
+	if confWith <= confNo {
+		t.Fatalf("expected higher confidence with matching GrandparentTitleSort: %g vs %g", confWith, confNo)
+	}
+}
+
+func TestFindBestMatchWithOptionalArtistSortRetry_fetchesMetadataOnce(t *testing.T) {
+	t.Parallel()
+	var metadataGets int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		if strings.HasPrefix(r.URL.Path, "/library/metadata/") {
+			atomic.AddInt32(&metadataGets, 1)
+			fmt.Fprintf(w, `<?xml version="1.0"?><MediaContainer size="1">
+				<Artist ratingKey="900" title="Diana Gordon" titleSort="Wynter Gordon"/></MediaContainer>`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	cfg := &config.Config{
+		Plex: config.PlexConfig{
+			URL:                    ts.URL,
+			Token:                  "tok",
+			LibrarySectionID:       2,
+			MatchConfidencePercent: 92,
+		},
+	}
+	c := NewClient(cfg)
+	tracks := []PlexTrack{{
+		ID:                   "50",
+		Title:                "Dirty Talk",
+		Artist:               "Unrelated Plex Display Name Xq",
+		GrandparentRatingKey: "900",
+		Album:                "Dirty Talk",
+	}}
+	got := c.findBestMatchWithOptionalArtistSortRetry(context.Background(), tracks, "Dirty Talk", "Wynter Gordon", "Dirty Talk", false)
+	if got == nil || got.ID != "50" {
+		t.Fatalf("expected retry match via artist metadata, got %v", got)
+	}
+	if atomic.LoadInt32(&metadataGets) != 1 {
+		t.Fatalf("expected exactly one GET /library/metadata/, got %d", metadataGets)
+	}
+	if strings.TrimSpace(tracks[0].GrandparentTitleSort) != "Wynter Gordon" {
+		t.Fatalf("expected slice mutated with sort title, got %q", tracks[0].GrandparentTitleSort)
+	}
+}
+
+func TestFindBestMatchWithOptionalArtistSortRetry_noMetadataWhenPass1Works(t *testing.T) {
+	t.Parallel()
+	var metadataGets int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/library/metadata/") {
+			atomic.AddInt32(&metadataGets, 1)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	cfg := &config.Config{
+		Plex: config.PlexConfig{
+			URL:                    ts.URL,
+			Token:                  "tok",
+			LibrarySectionID:       2,
+			MatchConfidencePercent: config.DefaultMatchConfidencePercent,
+		},
+	}
+	c := NewClient(cfg)
+	tracks := []PlexTrack{{ID: "51", Title: "Honey", Artist: "Robyn", Album: "Body Talk", GrandparentRatingKey: "902"}}
+	got := c.findBestMatchWithOptionalArtistSortRetry(context.Background(), tracks, "Honey", "Robyn", "Body Talk", false)
+	if got == nil || got.ID != "51" {
+		t.Fatalf("expected Pass 1 match, got %v", got)
+	}
+	if atomic.LoadInt32(&metadataGets) != 0 {
+		t.Fatalf("expected zero metadata GET when Pass 1 succeeds, got %d", metadataGets)
+	}
+}
+
+func TestGrandparentKeysForLibrarySortEnrichment_respectsThresholdAndCap(t *testing.T) {
+	t.Parallel()
+	c := &Client{}
+	tracks := make([]PlexTrack, libraryArtistSortEnrichMaxKeys+3)
+	for i := range tracks {
+		tracks[i] = PlexTrack{
+			Title:                fmt.Sprintf("Other Song %d", i),
+			GrandparentRatingKey: fmt.Sprintf("k%d", i),
+			Artist:               "A",
+			GrandparentTitleSort: "",
+		}
+	}
+	tracks[0] = PlexTrack{Title: "Target Hit", GrandparentRatingKey: "best", Artist: "X"}
+	m := c.grandparentKeysForLibrarySortEnrichment(tracks, "Target Hit")
+	if len(m) != 1 {
+		t.Fatalf("want 1 key above threshold, got %d", len(m))
+	}
+	if _, ok := m["best"]; !ok {
+		t.Fatal("expected best key")
+	}
+}

--- a/plex/client.go
+++ b/plex/client.go
@@ -67,21 +67,28 @@ type Client struct {
 	exactMatchesOnly      bool
 	// matchConfidencePercent is the minimum combined match score (0–100) as a fraction in minMatchScore; nil means use config.DefaultMatchConfidencePercent (for tests using &Client{}).
 	matchConfidencePercent *int
+
+	artistSortMu    sync.Mutex
+	artistSortCache map[string]string // Plex artist ratingKey → titleSort from GET /library/metadata/{key}
 }
 
 // PlexTrack represents a track from Plex search and library API responses.
 // Artist is grandparentTitle (the album / library-hierarchy artist; often "Various Artists" on compilations).
 // OriginalTitle, when set, is the per-track artist (performer) — see Plex music Track attributes.
+// GrandparentRatingKey identifies the library Artist item; GrandparentTitleSort is Plex Artist titleSort (Sort Artist),
+// filled after optional metadata fetch when Pass 1 matching fails to reach min confidence.
 type PlexTrack struct {
-	ID            string `xml:"ratingKey,attr"`
-	Title         string `xml:"title,attr"`
-	Artist        string `xml:"grandparentTitle,attr"`
-	OriginalTitle string `xml:"originalTitle,attr"`
-	Album         string `xml:"parentTitle,attr"`
-	Duration      int    `xml:"duration,attr"`
-	AddedAt       string `xml:"addedAt,attr"`
-	UpdatedAt     string `xml:"updatedAt,attr"`
-	File          string `xml:"file,attr"`
+	ID                   string `xml:"ratingKey,attr"`
+	Title                string `xml:"title,attr"`
+	Artist               string `xml:"grandparentTitle,attr"`
+	OriginalTitle        string `xml:"originalTitle,attr"`
+	GrandparentRatingKey string `xml:"grandparentRatingKey,attr"`
+	GrandparentTitleSort string `xml:"-"` // from Artist metadata titleSort, not on Track XML
+	Album                string `xml:"parentTitle,attr"`
+	Duration             int    `xml:"duration,attr"`
+	AddedAt              string `xml:"addedAt,attr"`
+	UpdatedAt            string `xml:"updatedAt,attr"`
+	File                 string `xml:"file,attr"`
 }
 
 // DisplayArtist returns a label for user-facing output: the track artist when set, else the album artist.
@@ -102,6 +109,9 @@ func (t PlexTrack) exactTitleAndArtistMatch(titleLower, sourceArtistLower string
 		return true
 	}
 	if s := strings.TrimSpace(t.OriginalTitle); s != "" && sourceArtistLower == strings.ToLower(s) {
+		return true
+	}
+	if s := strings.TrimSpace(t.GrandparentTitleSort); s != "" && sourceArtistLower == strings.ToLower(s) {
 		return true
 	}
 	return false

--- a/plex/confidence.go
+++ b/plex/confidence.go
@@ -60,13 +60,18 @@ func (c *Client) artistSimilarityTitleArtistForPlexField(song track.Track, plexF
 	return artistSimilarity
 }
 
-// bestArtistSimilarityTitleArtist returns the best 0–1 match over grandparent and originalTitle.
+// bestArtistSimilarityTitleArtist returns the best 0–1 match over grandparent, originalTitle, and GrandparentTitleSort.
 func (c *Client) bestArtistSimilarityTitleArtist(song track.Track, plex *PlexTrack) float64 {
 	var best float64
 	if s := strings.TrimSpace(plex.Artist); s != "" {
 		best = c.artistSimilarityTitleArtistForPlexField(song, s)
 	}
 	if s := strings.TrimSpace(plex.OriginalTitle); s != "" {
+		if v := c.artistSimilarityTitleArtistForPlexField(song, s); v > best {
+			best = v
+		}
+	}
+	if s := strings.TrimSpace(plex.GrandparentTitleSort); s != "" {
 		if v := c.artistSimilarityTitleArtistForPlexField(song, s); v > best {
 			best = v
 		}

--- a/plex/playlist_diff.go
+++ b/plex/playlist_diff.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/grrywlsn/plexify/internal/cliutil"
-	"github.com/grrywlsn/plexify/track"
 	"golang.org/x/term"
 )
 
@@ -232,19 +231,19 @@ func fprintPlaylistDiff(w io.Writer, view PlaylistDiffView, useColor, outerBanne
 			src := ent.MatchResult.SourceTrack
 			pt := ent.MatchResult.PlexTrack
 			printLine(ansiGreen+ansiBold, fmt.Sprintf("+ %s: ", sourceServiceDisplayName)+formatArtistTitle(src.Artist, src.Name))
-			plexArtist := plexArtistForPlaylistDiffLine(src, pt)
+			plexArtist := playlistDiffPlexArtistLabel(pt)
 			printLine(ansiGreen, "+ plex:         "+formatArtistTitle(plexArtist, pt.Title)+fmt.Sprintf(" (confidence: %s)", formatConfidencePercent(ent.MatchResult.Confidence)))
 		case PlaylistDiffRemove:
 			pt := &view.Old[op.OldIdx]
-			printLine(ansiRed+ansiBold, "- plex:         "+formatArtistTitle(pt.DisplayArtist(), pt.Title))
+			printLine(ansiRed+ansiBold, "- plex:         "+formatArtistTitle(playlistDiffPlexArtistLabel(pt), pt.Title))
 		case PlaylistDiffChange:
 			oldTr := &view.Old[op.OldIdx]
 			ent := view.Desired[op.NewIdx]
 			src := ent.MatchResult.SourceTrack
 			newPt := ent.MatchResult.PlexTrack
-			printLine(ansiYellow+ansiBold, "~ was (plex):    "+formatArtistTitle(oldTr.DisplayArtist(), oldTr.Title))
+			printLine(ansiYellow+ansiBold, "~ was (plex):    "+formatArtistTitle(playlistDiffPlexArtistLabel(oldTr), oldTr.Title))
 			printLine(ansiYellow, "~ now (source): "+formatArtistTitle(src.Artist, src.Name))
-			nowPlexArtist := plexArtistForPlaylistDiffLine(src, newPt)
+			nowPlexArtist := playlistDiffPlexArtistLabel(newPt)
 			printLine(ansiYellow, "~ now (plex):   "+formatArtistTitle(nowPlexArtist, newPt.Title)+fmt.Sprintf(" (confidence: %s)", formatConfidencePercent(ent.MatchResult.Confidence)))
 		}
 		fmt.Fprintln(w, "")
@@ -255,37 +254,24 @@ func formatArtistTitle(artist, title string) string {
 	return fmt.Sprintf("%s - %s", artist, title)
 }
 
-// plexArtistForPlaylistDiffLine picks the Plex grandparent (album) or per-track (originalTitle) name
-// to show on diff lines by comparing each field against the source track’s search artist candidates,
-// using the same artistMatchSimilarity logic as FindBestMatch. When only one field is set, that
-// value is used. For rows without a source (e.g. old playlist items), use PlexTrack.DisplayArtist.
-func plexArtistForPlaylistDiffLine(src track.Track, tr *PlexTrack) string {
+// playlistDiffPlexArtistLabel formats album artist (grandparentTitle) with per-track performer or Sort Artist
+// when they differ, e.g. "Various Artists" as "Madonna" or "Diana Gordon" as "Wynter Gordon"; otherwise DisplayArtist().
+func playlistDiffPlexArtistLabel(tr *PlexTrack) string {
 	if tr == nil {
 		return ""
 	}
-	a := strings.TrimSpace(tr.Artist)
+	left := strings.TrimSpace(tr.Artist)
 	ot := strings.TrimSpace(tr.OriginalTitle)
-	if ot == "" {
-		return a
+	gs := strings.TrimSpace(tr.GrandparentTitleSort)
+	var right string
+	switch {
+	case ot != "" && !strings.EqualFold(left, ot):
+		right = ot // compilation / guest performer vs album artist
+	case gs != "" && !strings.EqualFold(left, gs):
+		right = gs // Sort Artist vs display artist (rename); skipped when ot already provides the alias
 	}
-	if a == "" {
-		return ot
+	if right != "" && left != "" {
+		return fmt.Sprintf(`"%s" as "%s"`, left, right)
 	}
-	var c Client
-	bestA := 0.0
-	for _, cand := range src.PlexSearchArtistCandidates() {
-		if s := c.artistMatchSimilarity(cand, a); s > bestA {
-			bestA = s
-		}
-	}
-	bestOt := 0.0
-	for _, cand := range src.PlexSearchArtistCandidates() {
-		if s := c.artistMatchSimilarity(cand, ot); s > bestOt {
-			bestOt = s
-		}
-	}
-	if bestOt >= bestA {
-		return ot
-	}
-	return a
+	return strings.TrimSpace(tr.DisplayArtist())
 }

--- a/plex/playlist_diff_test.go
+++ b/plex/playlist_diff_test.go
@@ -118,21 +118,38 @@ func TestFprintPlaylistDiff_noColor(t *testing.T) {
 	}
 }
 
-func TestPlexArtistForPlaylistDiffLine_variousArtists(t *testing.T) {
+func TestPlaylistDiffPlexArtistLabel_variousArtists(t *testing.T) {
 	t.Parallel()
-	src := track.Track{Artist: "Khalid", Name: "Love Lies"}
 	tr := &PlexTrack{Artist: "Various Artists", OriginalTitle: "Khalid", Title: "Love Lies"}
-	if got := plexArtistForPlaylistDiffLine(src, tr); got != "Khalid" {
-		t.Fatalf("expected per-track label when it matches source best, got %q", got)
+	want := `"Various Artists" as "Khalid"`
+	if got := playlistDiffPlexArtistLabel(tr); got != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }
 
-func TestPlexArtistForPlaylistDiffLine_albumArtistWhenStronger(t *testing.T) {
+func TestPlaylistDiffPlexArtistLabel_albumAndGuestOriginalTitle(t *testing.T) {
 	t.Parallel()
-	src := track.Track{Artist: "ABBA", Name: "Dancing Queen"}
 	tr := &PlexTrack{Artist: "ABBA", OriginalTitle: "Guest", Title: "Dancing Queen"}
-	if got := plexArtistForPlaylistDiffLine(src, tr); got != "ABBA" {
-		t.Fatalf("expected album artist when it matches better, got %q", got)
+	want := `"ABBA" as "Guest"`
+	if got := playlistDiffPlexArtistLabel(tr); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPlaylistDiffPlexArtistLabel_sortArtistRename(t *testing.T) {
+	t.Parallel()
+	tr := &PlexTrack{Artist: "Diana Gordon", GrandparentTitleSort: "Wynter Gordon", Title: "Dirty Talk"}
+	want := `"Diana Gordon" as "Wynter Gordon"`
+	if got := playlistDiffPlexArtistLabel(tr); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPlaylistDiffPlexArtistLabel_singleWhenNoAlias(t *testing.T) {
+	t.Parallel()
+	tr := &PlexTrack{Artist: "ABBA", Title: "Dancing Queen"}
+	if got := playlistDiffPlexArtistLabel(tr); got != "ABBA" {
+		t.Fatalf("got %q, want ABBA", got)
 	}
 }
 
@@ -154,8 +171,8 @@ func TestFprintPlaylistDiff_plexLineUsesBestArtistField(t *testing.T) {
 	if strings.Contains(out, "Various Artists - Love Lies") {
 		t.Fatalf("expected plex line to prefer matching track artist, got: %s", out)
 	}
-	if !strings.Contains(out, "Khalid - Love Lies") {
-		t.Fatalf("expected Khalid on plex line, got: %s", out)
+	if !strings.Contains(out, `"Various Artists" as "Khalid" - Love Lies`) {
+		t.Fatalf("expected dual artist label on plex line, got: %s", out)
 	}
 }
 

--- a/plex/search.go
+++ b/plex/search.go
@@ -274,7 +274,7 @@ func (c *Client) searchByTitle(ctx context.Context, title, artist, sourceAlbum s
 			c.debugLog("  Result %d: '%s' by '%s' (ID: %s)", i+1, track.Title, track.DisplayArtist(), track.ID)
 		}
 	}
-	result := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum)
+	result := c.findBestMatchWithOptionalArtistSortRetry(ctx, searchResp.Tracks, title, artist, sourceAlbum, false)
 	if result != nil {
 		slog.Debug(fmt.Sprintf("✅ searchByTitle: found match '%s' by '%s'", result.Title, result.DisplayArtist()))
 	} else {
@@ -317,7 +317,7 @@ func (c *Client) searchByArtist(ctx context.Context, title, artist, sourceAlbum 
 	}
 
 	// Find best match among search results
-	result := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum)
+	result := c.findBestMatchWithOptionalArtistSortRetry(ctx, searchResp.Tracks, title, artist, sourceAlbum, false)
 	if result != nil {
 		slog.Debug(fmt.Sprintf("✅ searchByArtist: found match '%s' by '%s'", result.Title, result.DisplayArtist()))
 	}
@@ -359,7 +359,7 @@ func (c *Client) searchByCombinedQuery(ctx context.Context, title, artist, sourc
 			"err", err, "query", query)
 		return nil, nil
 	}
-	if track := c.FindBestMatch(searchResp.Tracks, title, artist, sourceAlbum); track != nil {
+	if track := c.findBestMatchWithOptionalArtistSortRetry(ctx, searchResp.Tracks, title, artist, sourceAlbum, false); track != nil {
 		slog.Debug(fmt.Sprintf("✅ searchByCombinedQuery: found match '%s' by '%s'", track.Title, track.DisplayArtist()))
 		return track, nil
 	}
@@ -451,7 +451,7 @@ func (c *Client) searchEntireLibrary(ctx context.Context, title, artist, sourceA
 
 	// Find best match among all tracks
 	c.debugLog("🔍 searchEntireLibrary: searching for '%s' by '%s' in entire library (%d tracks)", title, artist, len(libraryResp.Tracks))
-	result := c.FindBestMatch(libraryResp.Tracks, title, artist, sourceAlbum)
+	result := c.findBestMatchWithOptionalArtistSortRetry(ctx, libraryResp.Tracks, title, artist, sourceAlbum, true)
 	if result != nil {
 		slog.Debug(fmt.Sprintf("✅ searchEntireLibrary: found match '%s' by '%s' for search '%s' by '%s'", result.Title, result.DisplayArtist(), title, artist))
 	} else {
@@ -523,10 +523,16 @@ func (c *Client) artistMatchSimilarity(artist, plexArtist string) float64 {
 	return artistSimilarity
 }
 
-// bestPlexTrackArtistSimilarity is the max artist similarity over grandparent (album) and originalTitle (track) when set.
+// bestPlexTrackArtistSimilarity is the max artist similarity over grandparent (album), originalTitle (track),
+// and GrandparentTitleSort (Plex Artist titleSort) when set.
 func (c *Client) bestPlexTrackArtistSimilarity(artist string, tr PlexTrack) float64 {
 	best := c.artistMatchSimilarity(artist, tr.Artist)
 	if s := strings.TrimSpace(tr.OriginalTitle); s != "" {
+		if v := c.artistMatchSimilarity(artist, s); v > best {
+			best = v
+		}
+	}
+	if s := strings.TrimSpace(tr.GrandparentTitleSort); s != "" {
 		if v := c.artistMatchSimilarity(artist, s); v > best {
 			best = v
 		}
@@ -539,6 +545,11 @@ func (c *Client) bestPlexTrackArtistSimilarityNormPunct(artist string, tr PlexTr
 	an := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(artist)))
 	sim := c.calculateStringSimilarity(an, strings.ToLower(strings.TrimSpace(c.normalizePunctuation(tr.Artist))))
 	if s := strings.TrimSpace(tr.OriginalTitle); s != "" {
+		if v := c.calculateStringSimilarity(an, strings.ToLower(strings.TrimSpace(c.normalizePunctuation(s)))); v > sim {
+			sim = v
+		}
+	}
+	if s := strings.TrimSpace(tr.GrandparentTitleSort); s != "" {
 		if v := c.calculateStringSimilarity(an, strings.ToLower(strings.TrimSpace(c.normalizePunctuation(s)))); v > sim {
 			sim = v
 		}
@@ -560,6 +571,12 @@ func (c *Client) plexTrackNormPunctTitleArtistMatch(tr PlexTrack, titleLower, ar
 	if s := strings.TrimSpace(tr.OriginalTitle); s != "" {
 		no := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(s)))
 		if artistLower == no {
+			return true
+		}
+	}
+	if s := strings.TrimSpace(tr.GrandparentTitleSort); s != "" {
+		ns := strings.ToLower(strings.TrimSpace(c.normalizePunctuation(s)))
+		if artistLower == ns {
 			return true
 		}
 	}

--- a/plex/search.go
+++ b/plex/search.go
@@ -44,6 +44,8 @@ type trackSearchStrategy struct {
 //
 // When the source artist field lists multiple names separated by commas (typical on music-social.com),
 // the primary (first) name is used first for Plex queries, then the full string is retried if needed.
+// When MusicBrainz artist_credits are present on the track, each distinct credit name is tried after that,
+// which often matches Plex display metadata without fetching Plex Artist titleSort.
 func (c *Client) SearchTrack(ctx context.Context, song track.Track) (*PlexTrack, MatchKind, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, MatchTypeError, fmt.Errorf("search cancelled: %w", err)

--- a/track/artist.go
+++ b/track/artist.go
@@ -42,14 +42,37 @@ func primaryBeforeAmpersand(s string) string {
 // The primary (first comma- or ampersand-listed) name is tried first so lookups match
 // typical single-artist Plex metadata; the full original string is tried second when it
 // differs (fallback for band names that legitimately contain commas or "&").
+// When MusicBrainzArtistCredits is set (music-social musicbrainz.artist_credits), each distinct
+// credit name is appended next—authoritative aliases that often align with Plex without extra API calls.
 func (t Track) PlexSearchArtistCandidates() []string {
+	seen := make(map[string]struct{})
+	var out []string
+	appendUnique := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		k := strings.ToLower(s)
+		if _, ok := seen[k]; ok {
+			return
+		}
+		seen[k] = struct{}{}
+		out = append(out, s)
+	}
+
 	full := strings.TrimSpace(t.Artist)
-	if full == "" {
+	if full != "" {
+		primary := PrimaryListedArtist(t.Artist)
+		appendUnique(primary)
+		if primary != full {
+			appendUnique(full)
+		}
+	}
+	for _, name := range t.MusicBrainzArtistCredits {
+		appendUnique(name)
+	}
+	if len(out) == 0 {
 		return []string{""}
 	}
-	primary := PrimaryListedArtist(t.Artist)
-	if primary == full {
-		return []string{full}
-	}
-	return []string{primary, full}
+	return out
 }

--- a/track/artist_test.go
+++ b/track/artist_test.go
@@ -43,4 +43,17 @@ func TestTrack_PlexSearchArtistCandidates(t *testing.T) {
 	if got := (Track{Artist: "SOPHIE & Bibi Bourelly"}).PlexSearchArtistCandidates(); !reflect.DeepEqual(got, wantAmp) {
 		t.Errorf("ampersand collab: got %v want %v", got, wantAmp)
 	}
+	mb := []string{"Wynter Gordon", "Diana Gordon"}
+	wantMB := []string{"Wynter Gordon", "Diana Gordon"}
+	if got := (Track{Artist: "Wynter Gordon", MusicBrainzArtistCredits: mb}).PlexSearchArtistCandidates(); !reflect.DeepEqual(got, wantMB) {
+		t.Errorf("mb dedupe with artist: got %v want %v", got, wantMB)
+	}
+	wantMB2 := []string{"Le Youth", "Le Youth, Forester, Robertson", "Guest"}
+	if got := (Track{Artist: "Le Youth, Forester, Robertson", MusicBrainzArtistCredits: []string{"Guest"}}).PlexSearchArtistCandidates(); !reflect.DeepEqual(got, wantMB2) {
+		t.Errorf("mb after comma artist: got %v want %v", got, wantMB2)
+	}
+	wantCreditsOnly := []string{"Diana Gordon"}
+	if got := (Track{MusicBrainzArtistCredits: []string{"Diana Gordon"}}).PlexSearchArtistCandidates(); !reflect.DeepEqual(got, wantCreditsOnly) {
+		t.Errorf("credits only: got %v want %v", got, wantCreditsOnly)
+	}
 }

--- a/track/track.go
+++ b/track/track.go
@@ -10,6 +10,10 @@ type Track struct {
 	ISRC                      string
 	MusicBrainzID             string // Recording MBID when known
 	MusicBrainzReleaseGroupID string // When set (from API), missing-track summary links to release group instead of recording
+	// MusicBrainzArtistCredits are performer names from music-social musicbrainz.artist_credits (when set).
+	// PlexSearchArtistCandidates tries each distinct name after the main Artist field so catalog aliases
+	// match Plex without an extra Plex Artist metadata fetch when possible.
+	MusicBrainzArtistCredits []string
 
 	// Streaming album identifiers from music-social.com JSON (optional).
 	SpotifyAlbumURI   string // e.g. spotify:album:{id} or https://open.spotify.com/album/...


### PR DESCRIPTION
This change improves matching when a source playlist still lists a former artist name (for example Wynter Gordon) while Plex stores the current display name on the album artist (Diana Gordon) and keeps the legacy name as Plex Sort Artist.

**Behaviour**
- Track XML now parses `grandparentRatingKey`. When the first scoring pass does not produce any candidate above the configured confidence floor, Plexify fetches `GET /library/metadata/{grandparentRatingKey}`, reads the Artist `titleSort`, and runs the same `FindBestMatch` logic a second time with that field available. Results are cached per artist rating key.
- Full-library search only considers Artist metadata for tracks whose title similarity to the query is at least 0.85, capped at 500 distinct artist keys, to avoid excessive HTTP when scanning the entire section.
- Confidence and all artist similarity helpers treat `GrandparentTitleSort` like other Plex artist strings.
- Playlist diff output shows both names when useful (for example `"Various Artists" as "Madonna"` or `"Diana Gordon" as "Wynter Gordon"`), including remove and change lines.

**Tests**
- Unit coverage for rename matching, VA interactions, two-phase metadata fetch (httptest), and playlist diff formatting.

Made with [Cursor](https://cursor.com)