### PR TITLE
fix(plex): avoid deadlock when artist-sort retry issues nested requests

### DIFF
--- a/plex/search.go
+++ b/plex/search.go
@@ -257,17 +257,19 @@ func (c *Client) searchByTitle(ctx context.Context, title, artist, sourceAlbum s
 	if err != nil {
 		return nil, fmt.Errorf("failed to make search request: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
 		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		return nil, newPlexHTTPError(resp.StatusCode, "search by title", b)
 	}
 
 	var searchResp PlexResponse
 	if err := decodePlexResponseXML(resp, &searchResp); err != nil {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("failed to decode search response: %w", err)
 	}
+	_ = resp.Body.Close()
 
 	// Find best match among search results
 	slog.Debug(fmt.Sprintf("🔍 searchByTitle: searching for '%s' by '%s', found %d results", title, artist, len(searchResp.Tracks)))
@@ -306,17 +308,19 @@ func (c *Client) searchByArtist(ctx context.Context, title, artist, sourceAlbum 
 	if err != nil {
 		return nil, fmt.Errorf("failed to make artist search request: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
 		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		return nil, newPlexHTTPError(resp.StatusCode, "search by artist", b)
 	}
 
 	var searchResp PlexResponse
 	if err := decodePlexResponseXML(resp, &searchResp); err != nil {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("failed to decode artist search response: %w", err)
 	}
+	_ = resp.Body.Close()
 
 	// Find best match among search results
 	result := c.findBestMatchWithOptionalArtistSortRetry(ctx, searchResp.Tracks, title, artist, sourceAlbum, false)
@@ -348,19 +352,21 @@ func (c *Client) searchByCombinedQuery(ctx context.Context, title, artist, sourc
 	if err != nil {
 		return nil, fmt.Errorf("failed to make combined search request: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
 		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		return nil, newPlexHTTPError(resp.StatusCode, "combined search", b)
 	}
 
 	var searchResp PlexResponse
 	if err := decodePlexResponseXML(resp, &searchResp); err != nil {
+		_ = resp.Body.Close()
 		slog.WarnContext(ctx, "combined Plex search returned OK but XML decode failed; trying other strategies",
 			"err", err, "query", query)
 		return nil, nil
 	}
+	_ = resp.Body.Close()
 	if track := c.findBestMatchWithOptionalArtistSortRetry(ctx, searchResp.Tracks, title, artist, sourceAlbum, false); track != nil {
 		slog.Debug(fmt.Sprintf("✅ searchByCombinedQuery: found match '%s' by '%s'", track.Title, track.DisplayArtist()))
 		return track, nil
@@ -439,17 +445,19 @@ func (c *Client) searchEntireLibrary(ctx context.Context, title, artist, sourceA
 	if err != nil {
 		return nil, fmt.Errorf("failed to make library request: %w", err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != StatusOK {
 		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 		return nil, newPlexHTTPError(resp.StatusCode, "library all", b)
 	}
 
 	var libraryResp PlexResponse
 	if err := decodePlexResponseXML(resp, &libraryResp); err != nil {
+		_ = resp.Body.Close()
 		return nil, fmt.Errorf("failed to decode library response: %w", err)
 	}
+	_ = resp.Body.Close()
 
 	// Find best match among all tracks
 	c.debugLog("🔍 searchEntireLibrary: searching for '%s' by '%s' in entire library (%d tracks)", title, artist, len(libraryResp.Tracks))

--- a/plex/search_test.go
+++ b/plex/search_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/grrywlsn/plexify/config"
 	"github.com/grrywlsn/plexify/track"
@@ -188,5 +190,139 @@ func TestSearchTrack_punctuationNormalizedQueryFindsPlexHyphenTitle(t *testing.T
 	}
 	if kind != MatchTypeTitleArtist {
 		t.Errorf("expected MatchTypeTitleArtist, got %s", kind)
+	}
+}
+
+func TestSearchByTitle_DoesNotDeadlockOnArtistSortRetry(t *testing.T) {
+	t.Parallel()
+
+	const sectionID = 2
+	var metadataGets int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch {
+		case r.URL.Path == fmt.Sprintf("/library/sections/%d/search", sectionID):
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><MediaContainer size="1">` +
+				`<Track ratingKey="1" title="Completely Different" grandparentTitle="Nope" grandparentRatingKey="900" parentTitle="X"/>` +
+				`</MediaContainer>`))
+			return
+		case strings.HasPrefix(r.URL.Path, "/library/metadata/"):
+			atomic.AddInt32(&metadataGets, 1)
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><MediaContainer size="1">` +
+				`<Artist ratingKey="900" title="Nope" titleSort="Still Nope"/>` +
+				`</MediaContainer>`))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer ts.Close()
+
+	cfg := &config.Config{
+		Plex: config.PlexConfig{
+			URL:                    ts.URL,
+			Token:                  "tok",
+			LibrarySectionID:       sectionID,
+			MatchConfidencePercent: 99,
+		},
+	}
+	c := NewClient(cfg)
+	done := make(chan struct{})
+	var (
+		got *PlexTrack
+		err error
+	)
+	go func() {
+		got, err = c.searchByTitle(context.Background(), "Wanted Song", "Wanted Artist", "Wanted Album")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("searchByTitle deadlocked while fetching artist metadata")
+	}
+
+	if err != nil {
+		t.Fatalf("searchByTitle returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no match, got %+v", got)
+	}
+	if atomic.LoadInt32(&metadataGets) == 0 {
+		t.Fatal("expected artist metadata retry request")
+	}
+}
+
+func TestSearchByCombinedQuery_DoesNotDeadlockOnArtistSortRetry(t *testing.T) {
+	t.Parallel()
+
+	const sectionID = 2
+	var (
+		searchGets   int32
+		metadataGets int32
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		switch {
+		case r.URL.Path == fmt.Sprintf("/library/sections/%d/search", sectionID):
+			atomic.AddInt32(&searchGets, 1)
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><MediaContainer size="1">` +
+				`<Track ratingKey="2" title="Wrong Track" grandparentTitle="Nope" grandparentRatingKey="901" parentTitle="Y"/>` +
+				`</MediaContainer>`))
+			return
+		case strings.HasPrefix(r.URL.Path, "/library/metadata/"):
+			atomic.AddInt32(&metadataGets, 1)
+			_, _ = w.Write([]byte(`<?xml version="1.0"?><MediaContainer size="1">` +
+				`<Artist ratingKey="901" title="Nope" titleSort="Still Nope"/>` +
+				`</MediaContainer>`))
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer ts.Close()
+
+	cfg := &config.Config{
+		Plex: config.PlexConfig{
+			URL:                    ts.URL,
+			Token:                  "tok",
+			LibrarySectionID:       sectionID,
+			MatchConfidencePercent: 99,
+		},
+	}
+	c := NewClient(cfg)
+
+	done := make(chan struct{})
+	var (
+		got *PlexTrack
+		err error
+	)
+	go func() {
+		got, err = c.searchByCombinedQuery(context.Background(), "Wanted Song", "Wanted Artist", "Wanted Album")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("searchByCombinedQuery deadlocked while fetching artist metadata")
+	}
+
+	if err != nil {
+		t.Fatalf("searchByCombinedQuery returned error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no match, got %+v", got)
+	}
+	if atomic.LoadInt32(&searchGets) == 0 {
+		t.Fatal("expected combined search request")
+	}
+	if atomic.LoadInt32(&metadataGets) == 0 {
+		t.Fatal("expected artist metadata retry request")
 	}
 }


### PR DESCRIPTION
## Summary
- close Plex search response bodies before invoking artist-sort retry logic to avoid re-entering the HTTP pipeline lock while still holding it
- apply the same close-before-retry behavior across title, artist, combined-query, and full-library search paths
- add regression tests for title and combined-query deadlock scenarios where artist metadata is fetched after initial search decode

## Test plan
- [x] go test ./plex
- [x] go test ./...

Made with [Cursor](https://cursor.com)