### PR TITLE
fix(lidarr): retry transient write failures with backoff

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -395,7 +395,11 @@ func (app *Application) addMissingReleaseGroupsToLidarr(ctx context.Context, mis
 		res, err := app.lidarr.AddReleaseGroupIfMissing(ctx, id)
 		if err != nil {
 			slog.Error("lidarr: add release group", "release_group", id, "err", err)
-			fmt.Printf("❌ Lidarr: could not add release group %s: %v\n", id, err)
+			if we, ok := lidarr.AsWriteError(err); ok {
+				fmt.Printf("❌ %s\n", we.UserMessage())
+			} else {
+				fmt.Printf("❌ Lidarr: could not add release group %s: %v\n", id, err)
+			}
 			continue
 		}
 		if res.AlreadyPresent {

--- a/lidarr/client.go
+++ b/lidarr/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -78,12 +79,50 @@ type AddReleaseGroupResult struct {
 // AddReleaseGroupIfMissing looks up a MusicBrainz release group (Lidarr foreign album id), adds it
 // with search when not already in the Lidarr library, or when already present forces album, releases,
 // and artist monitored via the Lidarr API so missing tracks stay visible.
+// Transient write failures (e.g. Lidarr SQLite read-only) are retried with exponential backoff.
 func (c *Client) AddReleaseGroupIfMissing(ctx context.Context, releaseGroupMBID string) (AddReleaseGroupResult, error) {
 	rid := strings.TrimSpace(releaseGroupMBID)
 	out := AddReleaseGroupResult{ReleaseGroupID: rid}
 	if rid == "" {
 		return out, fmt.Errorf("empty release group id")
 	}
+
+	var lastErr error
+	for attempt := 0; attempt < writeMaxAttempts; attempt++ {
+		if attempt > 0 {
+			delay := writeBackoffFunc(attempt - 1)
+			reason := lidarrFailureReason(lastErr)
+			slog.WarnContext(ctx, "lidarr: transient write error; retrying",
+				"release_group", rid, "attempt", attempt+1, "max", writeMaxAttempts, "backoff", delay, "reason", reason, "err", lastErr)
+			fmt.Printf("⏳ Lidarr: temporarily unavailable (%s); retrying in %s (%d/%d)\n",
+				reason, delay.Round(time.Second), attempt+1, writeMaxAttempts)
+			select {
+			case <-ctx.Done():
+				return out, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		res, err := c.addReleaseGroupIfMissingOnce(ctx, rid)
+		if err == nil {
+			return res, nil
+		}
+		lastErr = err
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		if !isTransientLidarrErr(err) {
+			return out, err
+		}
+		if attempt+1 >= writeMaxAttempts {
+			return out, &WriteError{ReleaseGroupID: rid, Reason: lidarrFailureReason(err)}
+		}
+	}
+	return out, &WriteError{ReleaseGroupID: rid, Reason: lidarrFailureReason(lastErr)}
+}
+
+func (c *Client) addReleaseGroupIfMissingOnce(ctx context.Context, rid string) (AddReleaseGroupResult, error) {
+	out := AddReleaseGroupResult{ReleaseGroupID: rid}
 
 	existing, err := c.fetchAlbumsByForeignAlbumID(ctx, rid)
 	if err != nil {

--- a/lidarr/errors.go
+++ b/lidarr/errors.go
@@ -1,0 +1,150 @@
+package lidarr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const defaultWriteMaxAttempts = 6
+
+var (
+	writeMaxAttempts = defaultWriteMaxAttempts
+	writeBackoffFunc = defaultWriteBackoff
+)
+
+func defaultWriteBackoff(attempt int) time.Duration {
+	delay := 5 * time.Second
+	for i := 0; i < attempt; i++ {
+		delay *= 2
+		if delay > 60*time.Second {
+			return 60 * time.Second
+		}
+	}
+	return delay
+}
+
+// WriteError is returned when Lidarr could not persist changes after retries (e.g. read-only database).
+type WriteError struct {
+	ReleaseGroupID string
+	Reason         string
+}
+
+func (e *WriteError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Reason != "" {
+		return fmt.Sprintf("could not write to Lidarr for release group %s: %s", e.ReleaseGroupID, e.Reason)
+	}
+	return fmt.Sprintf("could not write to Lidarr for release group %s", e.ReleaseGroupID)
+}
+
+// UserMessage is a short CLI-friendly message that prompts the user to re-run Plexify.
+func (e *WriteError) UserMessage() string {
+	if e == nil {
+		return ""
+	}
+	if e.Reason != "" {
+		return fmt.Sprintf("Lidarr could not save changes for release group %s (%s). Once Lidarr is healthy, re-run Plexify to retry.", e.ReleaseGroupID, e.Reason)
+	}
+	return fmt.Sprintf("Lidarr could not save changes for release group %s. Once Lidarr is healthy, re-run Plexify to retry.", e.ReleaseGroupID)
+}
+
+// AsWriteError reports whether err is or wraps a *WriteError.
+func AsWriteError(err error) (*WriteError, bool) {
+	var we *WriteError
+	if errors.As(err, &we) && we != nil {
+		return we, true
+	}
+	return nil, false
+}
+
+func isTransientLidarrErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var uErr *url.Error
+	if errors.As(err, &uErr) && uErr.Err != nil {
+		if ne, ok := uErr.Err.(net.Error); ok && ne.Timeout() {
+			return true
+		}
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "readonly database") {
+		return true
+	}
+	for _, code := range []int{
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	} {
+		if strings.Contains(msg, fmt.Sprintf(": %d ", code)) {
+			return true
+		}
+	}
+	return false
+}
+
+func lidarrFailureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "readonly database"):
+		return "database read-only"
+	case strings.Contains(lower, "connection refused"):
+		return "connection refused"
+	case strings.Contains(lower, "timeout"):
+		return "timeout"
+	case strings.Contains(lower, "internal server error"):
+		return "server error"
+	default:
+		if i := strings.Index(msg, ": "); i >= 0 && len(msg) > i+2 {
+			rest := strings.TrimSpace(msg[i+2:])
+			if j := strings.Index(rest, "\n"); j >= 0 {
+				rest = strings.TrimSpace(rest[:j])
+			}
+			if len(rest) > 120 {
+				rest = rest[:120] + "…"
+			}
+			if rest != "" {
+				return rest
+			}
+		}
+		return "unavailable"
+	}
+}

--- a/lidarr/errors_test.go
+++ b/lidarr/errors_test.go
@@ -1,0 +1,175 @@
+package lidarr
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grrywlsn/plexify/config"
+)
+
+func TestIsTransientLidarrErr(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{err: nil, want: false},
+		{err: context.Canceled, want: false},
+		{err: context.DeadlineExceeded, want: true},
+		{err: fmtError("PUT album 1: 500 Internal Server Error: readonly database"), want: true},
+		{err: fmtError("add album: 503 Service Unavailable"), want: true},
+		{err: fmtError("Lidarr album/lookup returned no results for release group x"), want: false},
+		{err: fmtError("GET album 1: 404 Not Found"), want: false},
+	}
+	for _, tc := range cases {
+		if got := isTransientLidarrErr(tc.err); got != tc.want {
+			t.Errorf("isTransientLidarrErr(%v) = %v, want %v", tc.err, got, tc.want)
+		}
+	}
+}
+
+type fmtError string
+
+func (e fmtError) Error() string { return string(e) }
+
+func TestWriteErrorUserMessage(t *testing.T) {
+	we := &WriteError{ReleaseGroupID: "abc-123", Reason: "database read-only"}
+	msg := we.UserMessage()
+	if msg == "" || !containsAll(msg, "abc-123", "re-run Plexify", "database read-only") {
+		t.Fatalf("unexpected message: %q", msg)
+	}
+}
+
+func containsAll(s string, parts ...string) bool {
+	for _, p := range parts {
+		if !strings.Contains(s, p) {
+			return false
+		}
+	}
+	return true
+}
+
+func withFastLidarrRetries(t *testing.T) {
+	t.Helper()
+	oldMax := writeMaxAttempts
+	oldBackoff := writeBackoffFunc
+	t.Cleanup(func() {
+		writeMaxAttempts = oldMax
+		writeBackoffFunc = oldBackoff
+	})
+	writeMaxAttempts = 4
+	writeBackoffFunc = func(int) time.Duration { return time.Millisecond }
+}
+
+func TestAddReleaseGroupIfMissing_RetriesTransientWrite(t *testing.T) {
+	withFastLidarrRetries(t)
+
+	mbid := "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	var putCalls atomic.Int32
+	readonlyBody := `{"message":"attempt to write a readonly database"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album" && r.URL.Query().Get("foreignAlbumId") == mbid:
+			_, _ = w.Write([]byte(`[{"id":42,"foreignAlbumId":"` + mbid + `"}]`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/album/monitor":
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album/42":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": 42.0, "monitored": false,
+				"artist": map[string]interface{}{"id": 7.0, "monitored": false},
+				"releases": []interface{}{
+					map[string]interface{}{"id": 1.0, "monitored": false},
+				},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/album/42":
+			n := putCalls.Add(1)
+			if n < 3 {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(readonlyBody))
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/artist/7":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": 7.0, "monitored": false})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/artist/7":
+			w.WriteHeader(http.StatusAccepted)
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(&config.LidarrConfig{URL: srv.URL, Token: "key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := c.AddReleaseGroupIfMissing(context.Background(), mbid)
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if !res.AlreadyPresent || !res.EnsuredMonitored {
+		t.Fatalf("got %#v", res)
+	}
+	if putCalls.Load() != 3 {
+		t.Fatalf("expected 3 PUT album attempts, got %d", putCalls.Load())
+	}
+}
+
+func TestAddReleaseGroupIfMissing_WriteErrorAfterRetries(t *testing.T) {
+	withFastLidarrRetries(t)
+
+	mbid := "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+	readonlyBody := `{"message":"attempt to write a readonly database"}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album" && r.URL.Query().Get("foreignAlbumId") == mbid:
+			_, _ = w.Write([]byte(`[{"id":99,"foreignAlbumId":"` + mbid + `"}]`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/album/monitor":
+			w.WriteHeader(http.StatusAccepted)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/album/99":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": 99.0, "monitored": false,
+				"artist": map[string]interface{}{"id": 8.0, "monitored": false},
+				"releases": []interface{}{
+					map[string]interface{}{"id": 2.0, "monitored": false},
+				},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/album/99":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(readonlyBody))
+		default:
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(&config.LidarrConfig{URL: srv.URL, Token: "key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.AddReleaseGroupIfMissing(context.Background(), mbid)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	we, ok := AsWriteError(err)
+	if !ok {
+		t.Fatalf("expected WriteError, got %T: %v", err, err)
+	}
+	if we.ReleaseGroupID != mbid {
+		t.Fatalf("release group: %q", we.ReleaseGroupID)
+	}
+	if we.Reason != "database read-only" {
+		t.Fatalf("reason: %q", we.Reason)
+	}
+	if !containsAll(we.UserMessage(), "re-run Plexify", mbid) {
+		t.Fatalf("user message: %q", we.UserMessage())
+	}
+}


### PR DESCRIPTION
## Summary
- Retry Lidarr release-group writes up to 6 times with exponential backoff when failures look transient (read-only SQLite, 5xx, timeouts, connection errors).
- Print a short progress line while waiting between retries.
- After retries are exhausted, show a clean CLI message prompting the user to re-run Plexify once Lidarr is healthy.

## Test plan
- [x] `go test ./...`
- [x] Added tests for transient error detection, successful retry after read-only failures, and `WriteError` after exhausted retries


Made with [Cursor](https://cursor.com)